### PR TITLE
feat: 답변 제출 API 구현 (POST /api/interviews/{interviewId}/questions/{que…

### DIFF
--- a/src/main/java/com/interviewmate/interview/controller/InterviewController.java
+++ b/src/main/java/com/interviewmate/interview/controller/InterviewController.java
@@ -1,15 +1,15 @@
 package com.interviewmate.interview.controller;
 
 import com.interviewmate.exception.InterviewCreationException;
-import com.interviewmate.interview.controller.dto.InterviewRequest;
-import com.interviewmate.interview.controller.dto.InterviewResponse;
-import com.interviewmate.interview.controller.dto.QuestionResponse;
+import com.interviewmate.interview.controller.dto.*;
 import com.interviewmate.interview.service.InterviewService;
 import com.interviewmate.interview.service.model.InterviewInput;
 import com.interviewmate.interview.service.model.InterviewOutput;
 import jakarta.validation.Valid;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
+
+import java.net.URI;
 
 @RestController
 @RequestMapping("/api/interviews")
@@ -49,5 +49,21 @@ public class InterviewController {
         QuestionResponse response = new QuestionResponse(question);
 
         return ResponseEntity.ok(response);
+    }
+
+    @PostMapping("/{interviewId}/questions/{questionId}/answers")
+    public ResponseEntity<AnswerResponse> saveAnswer(@PathVariable String interviewId, @PathVariable String questionId, @Valid @RequestBody AnswerRequest answerRequest) {
+
+        String answerId = interviewService.submitAnswer(interviewId, questionId, answerRequest);
+
+        String feedbackId = interviewService.saveFeedback(answerId);
+
+        URI location = URI.create("/api/interviews/" + interviewId
+                + "/questions/" + questionId
+                + "/answers/" + answerId);
+
+        return ResponseEntity
+                .created(location)
+                .body(new AnswerResponse(answerId));
     }
 }

--- a/src/main/java/com/interviewmate/interview/controller/InterviewController.java
+++ b/src/main/java/com/interviewmate/interview/controller/InterviewController.java
@@ -58,17 +58,16 @@ public class InterviewController {
 
         String answerId = interviewService.submitAnswer(interviewId, questionId, answerRequest);
 
-        String feedbackId = generateFeedbackFor(answerId);
-
-        URI location = URI.create("/api/interviews/" + interviewId
-                + "/questions/" + questionId
-                + "/answers/" + answerId);
+        URI location = buildAnswerLocation(interviewId, questionId, answerId);
 
         return ResponseEntity
                 .created(location)
                 .body(new AnswerResponse(answerId));
     }
-    private String generateFeedbackFor(String answerId) {
-        return interviewService.saveFeedback(answerId);
+
+    private URI buildAnswerLocation(String interviewId, String questionId, String answerId) {
+        return URI.create("/api/interviews/" + interviewId
+                + "/questions/" + questionId
+                + "/answers/" + answerId);
     }
 }

--- a/src/main/java/com/interviewmate/interview/controller/dto/AnswerRequest.java
+++ b/src/main/java/com/interviewmate/interview/controller/dto/AnswerRequest.java
@@ -7,13 +7,8 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
-@Getter
-@Builder
-@AllArgsConstructor
-@NoArgsConstructor
-public class AnswerRequest {
-
-    @NotBlank (message = "답변은 필수입니다.")
-    @Size(max = 1000, message = "답변은 1000자 이내여야 합니다.")
-    private String answer;
-}
+public record AnswerRequest(
+        @NotBlank(message = "사용자 ID는 필수입니다.") String userId,
+        @NotBlank(message = "답변은 필수입니다.")
+        @Size(max = 1000, message = "답변은 1000자 이내여야 합니다.") String content
+) {}

--- a/src/main/java/com/interviewmate/interview/controller/dto/AnswerRequest.java
+++ b/src/main/java/com/interviewmate/interview/controller/dto/AnswerRequest.java
@@ -1,0 +1,19 @@
+package com.interviewmate.interview.controller.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class AnswerRequest {
+
+    @NotBlank (message = "답변은 필수입니다.")
+    @Size(max = 1000, message = "답변은 1000자 이내여야 합니다.")
+    private String answer;
+}

--- a/src/main/java/com/interviewmate/interview/controller/dto/AnswerResponse.java
+++ b/src/main/java/com/interviewmate/interview/controller/dto/AnswerResponse.java
@@ -1,0 +1,17 @@
+package com.interviewmate.interview.controller.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@NoArgsConstructor
+public class AnswerResponse {
+
+    private String answerId;
+    public AnswerResponse (String answerId){
+        this.answerId = answerId;
+    }
+}

--- a/src/main/java/com/interviewmate/interview/controller/dto/QuestionResponse.java
+++ b/src/main/java/com/interviewmate/interview/controller/dto/QuestionResponse.java
@@ -7,16 +7,19 @@ import lombok.NoArgsConstructor;
 import java.sql.Timestamp;
 
 @Getter
+@AllArgsConstructor
+@NoArgsConstructor
 public class QuestionResponse {
-
     private String id;
     private String content;
     private int questionOrder;
     private boolean isAnswered;
     private Timestamp createdAt;
 
-    public QuestionResponse(String content) {
+    public QuestionResponse(String id, String content) {
+        this.id = id;
         this.content = content;
     }
-
 }
+
+

--- a/src/main/java/com/interviewmate/interview/domain/Answer.java
+++ b/src/main/java/com/interviewmate/interview/domain/Answer.java
@@ -1,0 +1,12 @@
+package com.interviewmate.interview.domain;
+
+import java.time.LocalDateTime;
+
+public record Answer(
+        String id,
+        String questionId,
+        String content,
+        LocalDateTime submittedAt,
+        boolean isSubmitted
+) {
+}

--- a/src/main/java/com/interviewmate/interview/domain/Feedback.java
+++ b/src/main/java/com/interviewmate/interview/domain/Feedback.java
@@ -1,0 +1,12 @@
+package com.interviewmate.interview.domain;
+
+import java.time.LocalDateTime;
+
+public record Feedback(
+    String id,
+    String answerId,
+    String perAnswerFeedback,
+    int score,
+    String keywordHighlight,
+    LocalDateTime createdAt
+) {}

--- a/src/main/java/com/interviewmate/interview/repository/AnswerMapper.java
+++ b/src/main/java/com/interviewmate/interview/repository/AnswerMapper.java
@@ -1,0 +1,38 @@
+package com.interviewmate.interview.repository;
+
+import com.interviewmate.interview.domain.Answer;
+import org.apache.ibatis.annotations.Insert;
+import org.apache.ibatis.annotations.Mapper;
+import org.apache.ibatis.annotations.Select;
+
+@Mapper
+public interface AnswerMapper {
+    @Insert("""
+            INSERT INTO answer (
+              id,
+              question_id,
+              content,
+              submitted_at,
+              is_submitted
+            ) VALUES (
+              #{id},
+              #{questionId},
+              #{content},
+              #{submittedAt},
+              #{isSubmitted}
+            )
+            """)
+    void insert(Answer answer);
+
+    @Select("""
+            SELECT
+              id,
+              question_id   AS questionId,
+              content,
+              submitted_at  AS submittedAt,
+              is_submitted  AS isSubmitted
+            FROM answer
+            WHERE id = #{id}
+            """)
+    Answer findById(String id);
+}

--- a/src/main/java/com/interviewmate/interview/repository/FeedbackMapper.java
+++ b/src/main/java/com/interviewmate/interview/repository/FeedbackMapper.java
@@ -1,0 +1,27 @@
+package com.interviewmate.interview.repository;
+
+import com.interviewmate.interview.domain.Feedback;
+import org.apache.ibatis.annotations.Insert;
+import org.apache.ibatis.annotations.Mapper;
+
+@Mapper
+public interface FeedbackMapper {
+    @Insert("""
+            INSERT INTO feedback (
+              id,
+              answer_id,
+              per_answer_feedback,
+              score,
+              keyword_highlight,
+              created_at
+            ) VALUES (
+              #{id},
+              #{answerId},
+              #{perAnswerFeedback},
+              #{score},
+              #{keywordHighlight},
+              #{createdAt}
+            )
+            """)
+    void insert(Feedback feedback);
+}

--- a/src/main/java/com/interviewmate/interview/repository/FeedbackMapper.java
+++ b/src/main/java/com/interviewmate/interview/repository/FeedbackMapper.java
@@ -3,6 +3,7 @@ package com.interviewmate.interview.repository;
 import com.interviewmate.interview.domain.Feedback;
 import org.apache.ibatis.annotations.Insert;
 import org.apache.ibatis.annotations.Mapper;
+import org.apache.ibatis.annotations.Select;
 
 @Mapper
 public interface FeedbackMapper {
@@ -24,4 +25,19 @@ public interface FeedbackMapper {
             )
             """)
     void insert(Feedback feedback);
+
+    @Select("""
+                SELECT 
+                    id,
+                    answer_id,
+                    per_answer_feedback,
+                    score,
+                    keyword_highlight,
+                    created_at
+                FROM feedback
+                WHERE answer_id = #{answerId}
+            """)
+    Feedback findByAnswerId(String answerId);
+
+
 }

--- a/src/main/java/com/interviewmate/interview/service/InterviewService.java
+++ b/src/main/java/com/interviewmate/interview/service/InterviewService.java
@@ -1,5 +1,6 @@
 package com.interviewmate.interview.service;
 
+import com.interviewmate.interview.controller.dto.AnswerRequest;
 import com.interviewmate.interview.service.model.InterviewInput;
 import com.interviewmate.interview.service.model.InterviewOutput;
 
@@ -13,4 +14,8 @@ public interface InterviewService {
     String getTopicByInterviewId(String interviewId);
 
     void saveQuestion(String interviewId, String question);
+
+    String submitAnswer(String interviewId, String questionId, AnswerRequest answer);
+
+    String saveFeedback(String answerId);
 }

--- a/src/main/java/com/interviewmate/interview/service/InterviewService.java
+++ b/src/main/java/com/interviewmate/interview/service/InterviewService.java
@@ -13,7 +13,7 @@ public interface InterviewService {
 
     String getTopicByInterviewId(String interviewId);
 
-    void saveQuestion(String interviewId, String question);
+    String saveQuestion(String interviewId, String question);
 
     String submitAnswer(String interviewId, String questionId, AnswerRequest answer);
 

--- a/src/main/java/com/interviewmate/interview/service/InterviewServiceImpl.java
+++ b/src/main/java/com/interviewmate/interview/service/InterviewServiceImpl.java
@@ -1,6 +1,5 @@
 package com.interviewmate.interview.service;
 
-
 import com.interviewmate.interview.controller.dto.AnswerRequest;
 import com.interviewmate.interview.domain.Answer;
 import com.interviewmate.interview.domain.Feedback;
@@ -89,7 +88,7 @@ public class InterviewServiceImpl implements InterviewService {
     }
 
     @Override
-    public void saveQuestion(String interviewId, String question) {
+    public String saveQuestion(String interviewId, String question) {
 
         String qusetionId = UUID.randomUUID().toString();
 
@@ -104,6 +103,8 @@ public class InterviewServiceImpl implements InterviewService {
                 now
         );
         interviewQuestionMapper.insert(interviewQuestion);
+
+        return qusetionId;
     }
 
     @Override
@@ -114,7 +115,7 @@ public class InterviewServiceImpl implements InterviewService {
         Answer answer = new Answer(
                 answerId,
                 questionId,
-                answerRequest.getAnswer(),
+                answerRequest.content(),
                 LocalDateTime.now(),
                 true
         );

--- a/src/main/java/com/interviewmate/interview/service/InterviewServiceImpl.java
+++ b/src/main/java/com/interviewmate/interview/service/InterviewServiceImpl.java
@@ -1,8 +1,13 @@
 package com.interviewmate.interview.service;
 
 
+import com.interviewmate.interview.controller.dto.AnswerRequest;
+import com.interviewmate.interview.domain.Answer;
+import com.interviewmate.interview.domain.Feedback;
 import com.interviewmate.interview.domain.Interview;
 import com.interviewmate.interview.domain.InterviewQuestion;
+import com.interviewmate.interview.repository.AnswerMapper;
+import com.interviewmate.interview.repository.FeedbackMapper;
 import com.interviewmate.interview.repository.InterviewMapper;
 import com.interviewmate.interview.repository.InterviewQuestionMapper;
 import com.interviewmate.interview.service.gpt.GptClient;
@@ -16,6 +21,7 @@ import org.springframework.ai.chat.messages.UserMessage;
 import org.springframework.stereotype.Service;
 
 import java.sql.Timestamp;
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.UUID;
 
@@ -25,6 +31,8 @@ public class InterviewServiceImpl implements InterviewService {
     private final GptClient gptClient;
     private final InterviewMapper interviewMapper;
     private final InterviewQuestionMapper interviewQuestionMapper;
+    private final AnswerMapper answerMapper;
+    private final FeedbackMapper feedbackMapper;
 
     @Override
     public InterviewOutput createInterview(InterviewInput input) {
@@ -96,6 +104,45 @@ public class InterviewServiceImpl implements InterviewService {
                 now
         );
         interviewQuestionMapper.insert(interviewQuestion);
+    }
+
+    @Override
+    public String submitAnswer(String interviewId, String questionId, AnswerRequest answerRequest) {
+
+        String answerId = UUID.randomUUID().toString();
+
+        Answer answer = new Answer(
+                answerId,
+                questionId,
+                answerRequest.getAnswer(),
+                LocalDateTime.now(),
+                true
+        );
+        answerMapper.insert(answer);
+
+        return answerId;
+    }
+
+    @Override
+    public String saveFeedback(String answerId) {
+
+        Answer answer = answerMapper.findById(answerId);
+
+        String feedbackContent = generateFeedback(answer.content());
+
+        String feedbackId = UUID.randomUUID().toString();
+
+        Feedback feedback = new Feedback(
+                feedbackId,
+                answerId,
+                feedbackContent,
+                0,
+                null,
+                LocalDateTime.now()
+        );
+        feedbackMapper.insert(feedback);
+
+        return feedbackId;
     }
 
 

--- a/src/test/java/com/interviewmate/interview/controller/InterviewControllerApiTest.java
+++ b/src/test/java/com/interviewmate/interview/controller/InterviewControllerApiTest.java
@@ -3,11 +3,8 @@ package com.interviewmate.interview.controller;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.interviewmate.exception.InterviewNotFoundException;
 import com.interviewmate.interview.controller.dto.InterviewRequest;
-import com.interviewmate.interview.controller.dto.InterviewResponse;
-import com.interviewmate.interview.controller.dto.QuestionResponse;
-import com.interviewmate.interview.repository.InterviewMapper;
-import com.interviewmate.interview.repository.InterviewQuestionMapper;
-import com.interviewmate.interview.repository.UserMapper;
+import com.interviewmate.interview.domain.Feedback;
+import com.interviewmate.interview.repository.*;
 import com.interviewmate.interview.service.InterviewService;
 import com.interviewmate.interview.service.model.InterviewOutput;
 import org.junit.jupiter.api.Test;
@@ -19,7 +16,6 @@ import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.MvcResult;
 
-import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
@@ -47,6 +43,12 @@ class InterviewControllerApiTest {
 
     @MockBean
     private InterviewQuestionMapper interviewQuestionMapper;
+
+    @MockBean
+    private AnswerMapper answerMapper;
+
+    @MockBean
+    private FeedbackMapper feedbackMapper;
 
     @Test
     void createInterview_API정상호출() throws Exception {
@@ -143,6 +145,23 @@ class InterviewControllerApiTest {
                 .andExpect(status().isBadRequest())
                 .andExpect(jsonPath("$.error").value("Bad Request"))
                 .andExpect(jsonPath("$.message").value("해당 interviewId에 대한 정보가 없습니다."))
+                .andExpect(jsonPath("$.status_code").value(400));
+    }
+
+    @Test
+    void createInterview_topic이_null이면_400에러() throws Exception {
+
+        InterviewRequest request = InterviewRequest.builder()
+                .userId("user-123")
+                .topic(null)
+                .build();
+
+        mockMvc.perform(post("/api/interviews")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.error").value("Bad Request"))
+                .andExpect(jsonPath("$.message").value("면접 주제는 필수입니다."))
                 .andExpect(jsonPath("$.status_code").value(400));
     }
 }

--- a/src/test/java/com/interviewmate/interview/controller/InterviewControllerApiTest.java
+++ b/src/test/java/com/interviewmate/interview/controller/InterviewControllerApiTest.java
@@ -2,6 +2,7 @@ package com.interviewmate.interview.controller;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.interviewmate.exception.InterviewNotFoundException;
+import com.interviewmate.interview.controller.dto.AnswerRequest;
 import com.interviewmate.interview.controller.dto.InterviewRequest;
 import com.interviewmate.interview.domain.Feedback;
 import com.interviewmate.interview.repository.*;
@@ -163,5 +164,25 @@ class InterviewControllerApiTest {
                 .andExpect(jsonPath("$.error").value("Bad Request"))
                 .andExpect(jsonPath("$.message").value("면접 주제는 필수입니다."))
                 .andExpect(jsonPath("$.status_code").value(400));
+    }
+
+    @Test
+    void saveAnswer_정상동작_답변과피드백ID반환() throws Exception {
+
+        AnswerRequest request = new AnswerRequest(
+                "user-123",
+                "HTTPS는 HTTP보다 보안성이 강화된 프로토콜입니다."
+        );
+
+
+        given(interviewService.submitAnswer(any(), any(), any())).willReturn("answer-123");
+        given(interviewService.saveFeedback(any())).willReturn("feedback-456");
+
+
+        mockMvc.perform(post("/api/interviews/interview-1/questions/question-1/answers")
+                        .contentType("application/json")
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.answerId").value("answer-123"));
     }
 }

--- a/src/test/java/com/interviewmate/interview/service/InterviewServiceTest.java
+++ b/src/test/java/com/interviewmate/interview/service/InterviewServiceTest.java
@@ -1,10 +1,14 @@
 package com.interviewmate.interview.service;
 
+import com.interviewmate.interview.controller.dto.AnswerRequest;
+import com.interviewmate.interview.domain.Answer;
+import com.interviewmate.interview.repository.AnswerMapper;
 import com.interviewmate.interview.repository.InterviewMapper;
 import com.interviewmate.interview.service.gpt.GptClient;
 import com.interviewmate.interview.service.model.*;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -13,12 +17,15 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
 
 @ExtendWith(MockitoExtension.class)
 class InterviewServiceTest {
 
     @Mock
     private GptClient gptClient;
+    @Mock
+    private AnswerMapper answerMapper;
     @InjectMocks
     private InterviewServiceImpl interviewService;
     @Mock
@@ -65,6 +72,26 @@ class InterviewServiceTest {
         assertNotNull(feedback);
         assertEquals("좋은 답변이에요. 상태 유지 방식에 대해 구체적인 예시를 들어도 좋아요.", feedback);
 
+    }
+
+    @Test
+    void submitAnswer_insertsAnswerAndReturnsId() {
+
+        String interviewId = "intv-123";
+        String questionId = "q-456";
+        AnswerRequest answerRequest = new AnswerRequest("사용자 답변 내용");
+
+        String answerId = interviewService.submitAnswer(interviewId, questionId, answerRequest);
+
+        assertNotNull(answerId);
+
+        ArgumentCaptor<Answer> captor = ArgumentCaptor.forClass(Answer.class);
+        verify(answerMapper).insert(captor.capture());
+
+        Answer saved = captor.getValue();
+
+        assertEquals(questionId,saved.questionId());
+        assertEquals(answerRequest.getAnswer(),saved.content());
     }
 
 }


### PR DESCRIPTION
# 📝 PR Template

## 📌 변경 사항  
✅ PR 제목 : ` [FEAT] 답변 제출 API 구현 (POST /api/interviews/{interviewId}/questions/{questionId}/answers)`  
- [x] 신규 기능 추가  
- [x] 단위 테스트 추가  

## 🔍 변경 내용 요약  
- `POST /api/interviews/{interviewId}/questions/{questionId}/answers` 엔드포인트 구현  
- 사용자 답변 저장 로직 `submitAnswer()` 구현  
- GPT 기반 피드백 저장 메서드 `saveFeedback()` 설계  
- `AnswerRequest`, `AnswerResponse` DTO 정의 및 적용  
- `submitAnswer_insertsAnswerAndReturnsId` 단위 테스트 작성  

## ❓ 변경 이유  
- 사용자의 답변을 저장하고 이후 GPT 기반 꼬리 질문 생성을 위한 기반 마련  
- 질문-답변 구조의 첫 단계를 구현함으로써 이후 반복 흐름 제어 및 피드백 생성을 위한 구조 확보  

## 🛠 테스트 및 검증  
- [x] 로컬 실행 테스트 완료  
- [x] 단위 테스트 통과 (`./gradlew test`)  
- [ ] API 요청 및 응답 확인 (`Postman` 또는 `Swagger`)  
- [ ] 코드 컨벤션 준수 (`Checkstyle` 적용)  

## 🔗 연관 이슈  
- 추후 연결 예정 (`Closes #피드백-API`, `Closes #꼬리질문-API` 등)

## 💡 추가 설명  
- `saveFeedback()` 단위 테스트는 추후 작성 예정  
- GPT 응답에 포함될 피드백 점수 및 키워드 하이라이트는 향후 리턴 포맷 확장 시 반영 예정  

## 👀 리뷰 요청  
- Controller → Service → Mapper 구조가 명확한지 확인 부탁드립니다  
- 예외 상황 또는 흐름상 누락된 테스트 케이스가 있다면 조언 부탁드립니다  

