### PR TITLE
feat(logging): 요청 추적을 위한 Filter 기반 requestId 로깅 도입

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -36,6 +36,8 @@ dependencies {
 	implementation 'org.springframework.ai:spring-ai-openai-spring-boot-starter:0.8.1'
 	implementation 'jakarta.validation:jakarta.validation-api:3.0.2'
 	implementation 'org.hibernate.validator:hibernate-validator:8.0.0.Final'
+	implementation 'net.logstash.logback:logstash-logback-encoder:7.4'
+
 
 	compileOnly 'org.projectlombok:lombok'
 	compileOnly 'org.springframework.boot:spring-boot-configuration-processor'

--- a/src/main/java/com/interviewmate/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/interviewmate/exception/GlobalExceptionHandler.java
@@ -7,25 +7,31 @@ import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ControllerAdvice;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import java.util.HashMap;
 import java.util.Map;
 
 @ControllerAdvice
 public class GlobalExceptionHandler {
 
+    private static final Logger errorLogger = LoggerFactory.getLogger("com.interviewmate.exception");
+
     @ExceptionHandler(HttpMessageNotReadableException.class)
     public ResponseEntity<Map<String, Object>> handleJsonParseError(HttpMessageNotReadableException ex) {
+        errorLogger.error("JSON 파싱 에러 발생: {}", ex.getMessage(), ex);
         return buildErrorResponse("Bad Request", "요청 형식이 잘못되었습니다.", 400);
     }
 
     @ExceptionHandler(InterviewNotFoundException.class)
     public ResponseEntity<Map<String, Object>> handleInterviewNotFound(InterviewNotFoundException ex) {
+        errorLogger.error("인터뷰 찾을 수 없음: {}", ex.getMessage(), ex);
         return buildErrorResponse("Bad Request", ex.getMessage(), 400);
     }
 
     @ExceptionHandler(MethodArgumentNotValidException.class)
     public ResponseEntity<Map<String, Object>> handleValidationError(MethodArgumentNotValidException ex) {
-
         String message = ex.getBindingResult()
                 .getFieldErrors()
                 .stream()
@@ -33,16 +39,17 @@ public class GlobalExceptionHandler {
                 .findFirst()
                 .orElse("잘못된 요청입니다.");
 
+        errorLogger.error("유효성 검사 실패: {}", message, ex);
         return buildErrorResponse("Bad Request", message, 400);
     }
 
     @ExceptionHandler(InterviewCreationException.class)
     public ResponseEntity<Map<String, Object>> handleInterviewCreationError(InterviewCreationException ex) {
+        errorLogger.error("인터뷰 생성 실패: {}", ex.getMessage(), ex);
         return buildErrorResponse("Interview Creation Failed", ex.getMessage(), 500);
     }
 
     private ResponseEntity<Map<String, Object>> buildErrorResponse(String error, String message, int statusCode) {
-
         Map<String, Object> body = new HashMap<>();
         body.put("error", error);
         body.put("message", message);
@@ -50,5 +57,9 @@ public class GlobalExceptionHandler {
 
         return new ResponseEntity<>(body, HttpStatus.valueOf(statusCode));
     }
-
+    @ExceptionHandler(Exception.class)
+    public ResponseEntity<Map<String, Object>> handleUnhandledException(Exception ex) {
+        errorLogger.error("처리되지 않은 예외 발생: {}", ex.getMessage(), ex);
+        return buildErrorResponse("Internal Server Error", "서버 내부 에러가 발생했습니다.", 500);
+    }
 }

--- a/src/main/java/com/interviewmate/interview/service/InterviewServiceImpl.java
+++ b/src/main/java/com/interviewmate/interview/service/InterviewServiceImpl.java
@@ -20,6 +20,7 @@ import org.springframework.ai.chat.messages.UserMessage;
 import org.springframework.stereotype.Service;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.slf4j.MDC;
 
 
 import java.sql.Timestamp;
@@ -57,7 +58,7 @@ public class InterviewServiceImpl implements InterviewService {
         long start = System.currentTimeMillis();
         interviewMapper.insert(interview);
         long elapsed = System.currentTimeMillis() - start;
-        logger.info("⏱️ interview 저장 시간: {}ms", elapsed);
+        MDC.put("dbElapsed", String.valueOf(elapsed));
 
         return new InterviewOutput(generatedId, input.getTopic());
     }
@@ -73,7 +74,7 @@ public class InterviewServiceImpl implements InterviewService {
         long gptStart = System.currentTimeMillis();
         AiChatResponse response = gptClient.generate(messages);
         long gptElapsed = System.currentTimeMillis() - gptStart;
-        logger.info("🌐 GPT 질문 생성 시간: {}ms", gptElapsed);
+        MDC.put("gptElapsed", String.valueOf(gptElapsed));
 
         return response.result().output().content();
     }
@@ -90,16 +91,22 @@ public class InterviewServiceImpl implements InterviewService {
         long start = System.currentTimeMillis();
         AiChatResponse response = gptClient.generate(messages);
         long elapsed = System.currentTimeMillis() - start;
-        logger.info("⏱️ GPT 피드백 생성 시간: {}ms", elapsed);
+        MDC.put("gptElapsed", String.valueOf(elapsed));
         return response.result().output().content();
     }
 
     @Override
     public String getTopicByInterviewId(String interviewId) {
 
+        long start = System.currentTimeMillis();
+
         Interview interview = interviewMapper.findById(interviewId);
 
+        long dbElapsed = System.currentTimeMillis() - start;
+        MDC.put("dbElapsed", String.valueOf(dbElapsed));
+
         return interview.topic();
+
     }
 
     @Override
@@ -120,7 +127,7 @@ public class InterviewServiceImpl implements InterviewService {
         long start = System.currentTimeMillis();
         interviewQuestionMapper.insert(interviewQuestion);
         long elapsed = System.currentTimeMillis() - start;
-        logger.info("🗃️ question 저장 시간: {}ms", elapsed);
+        MDC.put("dbElapsed", String.valueOf(elapsed));
 
         return qusetionId;
     }
@@ -141,7 +148,7 @@ public class InterviewServiceImpl implements InterviewService {
         long start = System.currentTimeMillis();
         answerMapper.insert(answer);
         long elapsed = System.currentTimeMillis() - start;
-        logger.info("🗃️ answer 저장 시간: {}ms", elapsed);
+        MDC.put("dbElapsed", String.valueOf(elapsed));
 
         return answerId;
     }
@@ -154,7 +161,7 @@ public class InterviewServiceImpl implements InterviewService {
         long gptStart = System.currentTimeMillis();
         String feedbackContent = generateFeedback(answer.content());
         long gptElapsed = System.currentTimeMillis() - gptStart;
-        logger.info("⏱️ GPT 피드백 생성 시간: {}ms", gptElapsed);
+        MDC.put("gptElapsed", String.valueOf(gptElapsed));
 
         String feedbackId = UUID.randomUUID().toString();
 
@@ -171,7 +178,7 @@ public class InterviewServiceImpl implements InterviewService {
         long dbStart = System.currentTimeMillis();
         feedbackMapper.insert(feedback);
         long dbElapsed = System.currentTimeMillis() - dbStart;
-        logger.info("🗃️ feedback 저장 시간: {}ms", dbElapsed);
+        MDC.put("dbElapsed", String.valueOf(dbElapsed));
 
         return feedbackId;
     }

--- a/src/main/java/com/interviewmate/logging/RequestIdFilter.java
+++ b/src/main/java/com/interviewmate/logging/RequestIdFilter.java
@@ -1,0 +1,47 @@
+package com.interviewmate.logging;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.slf4j.MDC;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+import java.util.UUID;
+
+@Component
+public class RequestIdFilter extends OncePerRequestFilter {
+
+    private static final String REQUEST_ID_KEY = "requestId";
+    private static final org.slf4j.Logger logger = org.slf4j.LoggerFactory.getLogger(RequestIdFilter.class);
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request,
+                                    HttpServletResponse response,
+                                    FilterChain filterChain)
+            throws ServletException, IOException {
+
+        String requestId = UUID.randomUUID().toString();
+        MDC.put(REQUEST_ID_KEY, requestId);
+
+        logger.info("🔥 Filter 동작 확인 – URI: {}", request.getRequestURI());
+
+        long start = System.currentTimeMillis();
+
+        try {
+            filterChain.doFilter(request, response);
+        } finally {
+            long elapsed = System.currentTimeMillis() - start;
+            logger.info("요청 완료: method={}, uri={}, status={}, elapsed={}ms, requestId={}",
+                    request.getMethod(),
+                    request.getRequestURI(),
+                    response.getStatus(),
+                    elapsed,
+                    requestId
+            );
+            MDC.remove(REQUEST_ID_KEY);
+        }
+    }
+}

--- a/src/main/java/com/interviewmate/logging/RequestIdFilter.java
+++ b/src/main/java/com/interviewmate/logging/RequestIdFilter.java
@@ -31,7 +31,7 @@ public class RequestIdFilter extends OncePerRequestFilter {
         String requestId = UUID.randomUUID().toString();
         MDC.put(REQUEST_ID_KEY, requestId);
 
-        logger.info("Filter 진입 – URI: {}", request.getRequestURI());
+        logger.info("Filter approach – URI: {}", request.getRequestURI());
 
         long startTime = System.currentTimeMillis();
 
@@ -52,7 +52,7 @@ public class RequestIdFilter extends OncePerRequestFilter {
             }
 
 
-            logger.info("요청 완료 – method={}, uri={}, status={}, req={}, total={}ms, db={}ms, ai={}ms",
+            logger.info("Request completed– method={}, uri={}, status={}, req={}, total={}ms, db={}ms, ai={}ms",
                     request.getMethod(),
                     request.getRequestURI(),
                     response.getStatus(),

--- a/src/main/java/com/interviewmate/logging/RequestIdFilter.java
+++ b/src/main/java/com/interviewmate/logging/RequestIdFilter.java
@@ -4,6 +4,7 @@ import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
+import org.slf4j.Logger;
 import org.slf4j.MDC;
 import org.springframework.stereotype.Component;
 import org.springframework.web.filter.OncePerRequestFilter;
@@ -15,7 +16,7 @@ import java.util.UUID;
 public class RequestIdFilter extends OncePerRequestFilter {
 
     private static final String REQUEST_ID_KEY = "requestId";
-    private static final org.slf4j.Logger logger = org.slf4j.LoggerFactory.getLogger(RequestIdFilter.class);
+    private static final Logger logger = org.slf4j.LoggerFactory.getLogger(RequestIdFilter.class);
 
     @Override
     protected void doFilterInternal(HttpServletRequest request,

--- a/src/main/java/com/interviewmate/logging/RequestIdFilter.java
+++ b/src/main/java/com/interviewmate/logging/RequestIdFilter.java
@@ -27,22 +27,27 @@ public class RequestIdFilter extends OncePerRequestFilter {
         String requestId = UUID.randomUUID().toString();
         MDC.put(REQUEST_ID_KEY, requestId);
 
-        logger.info("🔥 Filter 동작 확인 – URI: {}", request.getRequestURI());
+        logger.info("Filter 동작 확인 – URI: {}", request.getRequestURI());
 
         long start = System.currentTimeMillis();
 
         try {
             filterChain.doFilter(request, response);
         } finally {
-            long elapsed = System.currentTimeMillis() - start;
-            logger.info("요청 완료: method={}, uri={}, status={}, elapsed={}ms, requestId={}",
+            long totalElapsed = System.currentTimeMillis() - start;
+
+            MDC.put(REQUEST_ID_KEY, requestId);
+            MDC.put("total",  String.valueOf(totalElapsed));
+            MDC.put("dbElapsed", MDC.get("dbElapsed"));
+            MDC.put("aiElapsed", MDC.get("aiElapsed"));
+
+            logger.info("요청 완료: method={}, uri={}, status={}",
                     request.getMethod(),
                     request.getRequestURI(),
-                    response.getStatus(),
-                    elapsed,
-                    requestId
+                    response.getStatus()
             );
-            MDC.remove(REQUEST_ID_KEY);
+
+            MDC.clear();
         }
     }
 }

--- a/src/main/resources/logback-spring.xml
+++ b/src/main/resources/logback-spring.xml
@@ -1,0 +1,53 @@
+<configuration>
+
+    <appender name="Console" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>
+                %d{yyyy-MM-dd HH:mm:ss.SSS} [%thread] %highlight(%-5level) %logger{36} -
+                [req=%X{requestId}] [total=%X{total:-0}ms] [db=%X{dbElapsed:-0}ms] [ai=%X{aiElapsed:-0}ms] %msg%n
+            </pattern>
+        </encoder>
+    </appender>
+
+    <appender name="AccessLogFile" class="ch.qos.logback.core.rolling.RollingFileAppender">
+        <file>logs/access.log</file>
+        <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
+            <fileNamePattern>logs/access.%d{yyyy-MM-dd}.log</fileNamePattern>
+            <maxHistory>7</maxHistory>
+        </rollingPolicy>
+        <encoder>
+            <pattern>
+                %d{yyyy-MM-dd HH:mm:ss.SSS} [%thread] %-5level %logger{36} -
+                [req=%X{requestId}] [total=%X{total:-0}ms] [db=%X{dbElapsed:-0}ms] [ai=%X{aiElapsed:-0}ms] %msg%n
+            </pattern>
+        </encoder>
+    </appender>
+
+    <appender name="ErrorLogFile" class="ch.qos.logback.core.rolling.RollingFileAppender">
+        <file>logs/error.log</file>
+        <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
+            <fileNamePattern>logs/error.%d{yyyy-MM-dd}.log</fileNamePattern>
+            <maxHistory>7</maxHistory>
+        </rollingPolicy>
+        <encoder>
+            <pattern>
+                %d{yyyy-MM-dd HH:mm:ss.SSS} [%thread] %-5level %logger{36} -
+                [req=%X{requestId}] [total=%X{total:-0}ms] [db=%X{dbElapsed:-0}ms] [ai=%X{aiElapsed:-0}ms] %msg%n%ex{full}
+            </pattern>
+        </encoder>
+    </appender>
+
+    <logger name="com.interviewmate" level="INFO" additivity="false">
+        <appender-ref ref="AccessLogFile"/>
+        <appender-ref ref="Console"/>
+    </logger>
+
+    <logger name="com.interviewmate.exception" level="ERROR" additivity="false">
+        <appender-ref ref="ErrorLogFile"/>
+    </logger>
+
+    <root level="INFO">
+        <appender-ref ref="Console"/>
+    </root>
+
+</configuration>

--- a/src/main/resources/logback-spring.xml
+++ b/src/main/resources/logback-spring.xml
@@ -1,11 +1,19 @@
 <configuration>
 
     <appender name="Console" class="ch.qos.logback.core.ConsoleAppender">
-        <encoder>
-            <pattern>
-                %d{yyyy-MM-dd HH:mm:ss.SSS} [%thread] %highlight(%-5level) %logger{36} -
-                [req=%X{requestId}] [total=%X{total:-0}ms] [db=%X{dbElapsed:-0}ms] [ai=%X{aiElapsed:-0}ms] %msg%n
-            </pattern>
+        <encoder class="net.logstash.logback.encoder.LoggingEventCompositeJsonEncoder">
+            <providers>
+                <timestamp>
+                    <fieldName>timestamp</fieldName>
+                    <pattern>yyyy-MM-dd HH:mm:ss.SSS</pattern>
+                </timestamp>
+                <threadName />
+                <logLevel />
+                <loggerName />
+                <mdc />
+                <message />
+                <stackTrace />
+            </providers>
         </encoder>
     </appender>
 
@@ -15,11 +23,15 @@
             <fileNamePattern>logs/access.%d{yyyy-MM-dd}.log</fileNamePattern>
             <maxHistory>7</maxHistory>
         </rollingPolicy>
-        <encoder>
-            <pattern>
-                %d{yyyy-MM-dd HH:mm:ss.SSS} [%thread] %-5level %logger{36} -
-                [req=%X{requestId}] [total=%X{total:-0}ms] [db=%X{dbElapsed:-0}ms] [ai=%X{aiElapsed:-0}ms] %msg%n
-            </pattern>
+        <encoder class="net.logstash.logback.encoder.LoggingEventCompositeJsonEncoder">
+            <providers>
+                <timestamp />
+                <threadName />
+                <logLevel />
+                <loggerName />
+                <mdc />
+                <message />
+            </providers>
         </encoder>
     </appender>
 
@@ -29,25 +41,30 @@
             <fileNamePattern>logs/error.%d{yyyy-MM-dd}.log</fileNamePattern>
             <maxHistory>7</maxHistory>
         </rollingPolicy>
-        <encoder>
-            <pattern>
-                %d{yyyy-MM-dd HH:mm:ss.SSS} [%thread] %-5level %logger{36} -
-                [req=%X{requestId}] [total=%X{total:-0}ms] [db=%X{dbElapsed:-0}ms] [ai=%X{aiElapsed:-0}ms] %msg%n%ex{full}
-            </pattern>
+        <encoder class="net.logstash.logback.encoder.LoggingEventCompositeJsonEncoder">
+            <providers>
+                <timestamp />
+                <threadName />
+                <logLevel />
+                <loggerName />
+                <mdc />
+                <message />
+                <stackTrace />
+            </providers>
         </encoder>
     </appender>
 
     <logger name="com.interviewmate" level="INFO" additivity="false">
-        <appender-ref ref="AccessLogFile"/>
-        <appender-ref ref="Console"/>
+        <appender-ref ref="AccessLogFile" />
+        <appender-ref ref="Console" />
     </logger>
 
     <logger name="com.interviewmate.exception" level="ERROR" additivity="false">
-        <appender-ref ref="ErrorLogFile"/>
+        <appender-ref ref="ErrorLogFile" />
     </logger>
 
     <root level="INFO">
-        <appender-ref ref="Console"/>
+        <appender-ref ref="Console" />
     </root>
 
 </configuration>

--- a/src/main/resources/logback-spring.xml
+++ b/src/main/resources/logback-spring.xml
@@ -1,23 +1,15 @@
 <configuration>
 
     <appender name="Console" class="ch.qos.logback.core.ConsoleAppender">
-        <encoder class="net.logstash.logback.encoder.LoggingEventCompositeJsonEncoder">
-            <providers>
-                <timestamp>
-                    <fieldName>timestamp</fieldName>
-                    <pattern>yyyy-MM-dd HH:mm:ss.SSS</pattern>
-                </timestamp>
-                <threadName />
-                <logLevel />
-                <loggerName />
-                <mdc />
-                <message />
-                <stackTrace />
-            </providers>
+        <encoder>
+            <pattern>
+                %d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n
+            </pattern>
         </encoder>
     </appender>
 
-    <appender name="AccessLogFile" class="ch.qos.logback.core.rolling.RollingFileAppender">
+    <appender name="AccessLogFile"
+              class="ch.qos.logback.core.rolling.RollingFileAppender">
         <file>logs/access.log</file>
         <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
             <fileNamePattern>logs/access.%d{yyyy-MM-dd}.log</fileNamePattern>
@@ -25,17 +17,21 @@
         </rollingPolicy>
         <encoder class="net.logstash.logback.encoder.LoggingEventCompositeJsonEncoder">
             <providers>
-                <timestamp />
-                <threadName />
-                <logLevel />
-                <loggerName />
-                <mdc />
-                <message />
+                <timestamp>
+                    <fieldName>timestamp</fieldName>
+                    <pattern>yyyy-MM-dd HH:mm:ss.SSS</pattern>
+                </timestamp>
+                <threadName/>
+                <logLevel/>
+                <loggerName/>
+                <mdc/>
+                <message/>
             </providers>
         </encoder>
     </appender>
 
-    <appender name="ErrorLogFile" class="ch.qos.logback.core.rolling.RollingFileAppender">
+    <appender name="ErrorLogFile"
+              class="ch.qos.logback.core.rolling.RollingFileAppender">
         <file>logs/error.log</file>
         <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
             <fileNamePattern>logs/error.%d{yyyy-MM-dd}.log</fileNamePattern>
@@ -43,28 +39,35 @@
         </rollingPolicy>
         <encoder class="net.logstash.logback.encoder.LoggingEventCompositeJsonEncoder">
             <providers>
-                <timestamp />
-                <threadName />
-                <logLevel />
-                <loggerName />
-                <mdc />
-                <message />
-                <stackTrace />
+                <timestamp/>
+                <threadName/>
+                <logLevel/>
+                <loggerName/>
+                <mdc/>
+                <message/>
+                <stackTrace/>
             </providers>
         </encoder>
     </appender>
 
-    <logger name="com.interviewmate" level="INFO" additivity="false">
-        <appender-ref ref="AccessLogFile" />
-        <appender-ref ref="Console" />
+
+    <logger name="com.interviewmate"
+            level="INFO"
+            additivity="false">
+        <appender-ref ref="AccessLogFile"/>
+        <appender-ref ref="Console"/>
     </logger>
 
-    <logger name="com.interviewmate.exception" level="ERROR" additivity="false">
-        <appender-ref ref="ErrorLogFile" />
+
+    <logger name="com.interviewmate.exception"
+            level="ERROR"
+            additivity="false">
+        <appender-ref ref="ErrorLogFile"/>
+        <appender-ref ref="Console"/>
     </logger>
 
     <root level="INFO">
-        <appender-ref ref="Console" />
+        <appender-ref ref="Console"/>
     </root>
 
 </configuration>


### PR DESCRIPTION
# 📝 PR Template

## 📌 변경 사항  
✅ PR 제목 예시: `[FEAT] 요청 추적 로깅 Filter 도입`  
- [x] 신규 기능 추가  
- [ ] 버그 수정  
- [ ] 코드 리팩토링  
- [ ] 문서 업데이트  
- [ ] 기타  

---

## 🔍 변경 내용 요약  
- UUID 기반 `requestId`를 생성하여 요청마다 식별 가능하도록 Filter 구현  
- SLF4J MDC를 통해 `requestId`를 ThreadLocal에 보관하고 로그 출력 시 자동 포함  
- 요청 시작/종료 시점에 method, uri, status, elapsed time, requestId가 함께 출력되도록 설정  
- `application.yml`에 로그 포맷 수정 (콘솔/파일 모두 `%X{requestId}` 포함)

---

## ❓ 변경 이유  
- Request 단위의 로그 추적을 위해 로깅 흐름의 기준점을 수립  
- 이후 AOP 기반 공통 로깅 및 분산 환경에서 로그 추적을 위한 사전 구조 구성  
- 기존의 개별 log.info 방식보다 흐름 단위로 기록되는 구조가 추적성과 유지보수 측면에서 더 유리하기 때문

---

## 🛠 테스트 및 검증  
- [x] 로컬 실행 테스트 완료  
- [x] Postman으로 API 요청 후 로그에 `requestId` 포함 확인  
- [ ] 단위 테스트 통과 (`./gradlew test`)  
- [x] 코드 컨벤션 준수 (기존 코드 스타일에 맞춰 작성)

---

## 🔗 연관 이슈  
- 없음 (설계 피드백 기반으로 자율 진행)

---

## 💡 추가 설명  
- 현재는 요청 단위(request) 흐름을 기준으로 로그를 남기기 위한 구조를 구성
- `Request → Response`까지의 흐름을 하나의 로그 흐름으로 추적할 수 있도록 requestId를 필터 단에서 생성/관리하고 있으며,  
  로그 출력 시 이를 함께 기록해 request 간 구분이 가능하도록 설계
- 이후에는 다음 확장 계획을 기반으로 추가 개선할 예정입니다:  
  - 로그 포맷 통일 및 가독성 개선  
  - DB/외부 API 통신 시간 별도 측정  
  - Access Log / Error Log 분리 기록  
  - 서비스 계층 로깅은 AOP 기반으로 공통 처리  

---

## 👀 리뷰 요청  
- 기본 구조가 괜찮은지 확인 부탁드립니다  
- 요청 단위의 MDC 처리 방식과 로그 구조 적절한지 검토 부탁드립니다.