### PR TITLE
[draft] feat: 인터뷰 다음 질문 생성 API 구현 (POST /api/interviews/{interviewId/questions/next

### DIFF
--- a/src/main/java/com/interviewmate/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/interviewmate/exception/GlobalExceptionHandler.java
@@ -62,4 +62,11 @@ public class GlobalExceptionHandler {
         errorLogger.error("처리되지 않은 예외 발생: {}", ex.getMessage(), ex);
         return buildErrorResponse("Internal Server Error", "서버 내부 에러가 발생했습니다.", 500);
     }
+
+    @ExceptionHandler(IllegalStateException.class)
+    public ResponseEntity<Map<String,Object>> handleBadState(IllegalStateException ex) {
+        errorLogger.warn("잘못된 인터뷰 흐름 상태: {}", ex.getMessage(), ex);
+        return buildErrorResponse("Bad Request", ex.getMessage(), 400);
+    }
+
 }

--- a/src/main/java/com/interviewmate/interview/controller/InterviewController.java
+++ b/src/main/java/com/interviewmate/interview/controller/InterviewController.java
@@ -3,7 +3,12 @@ package com.interviewmate.interview.controller;
 import ch.qos.logback.core.model.processor.PhaseIndicator;
 import com.interviewmate.exception.InterviewCreationException;
 import com.interviewmate.interview.controller.dto.*;
+import com.interviewmate.interview.domain.Answer;
+import com.interviewmate.interview.domain.Feedback;
+import com.interviewmate.interview.domain.InterviewQuestion;
 import com.interviewmate.interview.domain.Question;
+import com.interviewmate.interview.repository.AnswerMapper;
+import com.interviewmate.interview.repository.FeedbackMapper;
 import com.interviewmate.interview.service.InterviewService;
 import com.interviewmate.interview.service.model.InterviewInput;
 import com.interviewmate.interview.service.model.InterviewOutput;
@@ -20,15 +25,17 @@ import java.net.URI;
 public class InterviewController {
 
     private final InterviewService interviewService;
+    private final FeedbackMapper feedbackMapper;
+    private final AnswerMapper answerMapper;
 
-    public InterviewController(InterviewService interviewService) {
+    public InterviewController(InterviewService interviewService, FeedbackMapper feedbackMapper, AnswerMapper answerMapper) {
         this.interviewService = interviewService;
+        this.feedbackMapper = feedbackMapper;
+        this.answerMapper = answerMapper;
     }
 
     @PostMapping
-    @Operation(
-            description = "Start new interview"
-    )
+    @Operation(description = "Start new interview")
     public ResponseEntity<InterviewResponseDTO> createInterview(@Valid @RequestBody InterviewRequestDTO request) {
 
         InterviewInput input = new InterviewInput(request.getUserId(), request.getTopic());
@@ -45,9 +52,7 @@ public class InterviewController {
     }
 
     @PostMapping("/{interviewId}/questions")
-    @Operation(
-            description = "Generate interview question"
-    )
+    @Operation(description = "Generate interview question")
     public ResponseEntity<QuestionResponseDTO> createQuestions(@PathVariable String interviewId) {
 
         String topic = interviewService.getTopicByInterviewId(interviewId);
@@ -62,9 +67,7 @@ public class InterviewController {
     }
 
     @PostMapping("/{interviewId}/questions/{questionId}/answers")
-    @Operation(
-            description = "Submit only answer"
-    )
+    @Operation(description = "Submit only answer")
     @ResponseStatus(HttpStatus.CREATED)
     public ResponseEntity<AnswerResponseDTO> submitAnswerAndFeedback(@PathVariable String interviewId, @PathVariable String questionId, @Valid @RequestBody AnswerRequestDTO answerRequestDTO) {
 
@@ -84,13 +87,11 @@ public class InterviewController {
     }
 
     @PostMapping("{interviewId}/questions/next")
-    @Operation(
-            description = "Generate next interview question"
-    )
+    @Operation(description = "Generate next interview question")
     public ResponseEntity<QuestionResponseDTO> generateNextQuestion(@PathVariable String interviewId) {
 
-        Question nextQuestion = interviewService.generateNextQuestion(interviewId);
-        QuestionResponseDTO nextQuestionResponse = new QuestionResponseDTO(nextQuestion.id(), nextQuestion.content());
+        Question question = interviewService.generateNextQuestion(interviewId);
+        QuestionResponseDTO nextQuestionResponse = new QuestionResponseDTO(question.id(), question.content());
 
         return ResponseEntity.ok(nextQuestionResponse);
     }

--- a/src/main/java/com/interviewmate/interview/controller/InterviewController.java
+++ b/src/main/java/com/interviewmate/interview/controller/InterviewController.java
@@ -6,13 +6,12 @@ import com.interviewmate.interview.controller.dto.InterviewRequestDTO;
 import com.interviewmate.interview.controller.dto.InterviewResponseDTO;
 import com.interviewmate.interview.controller.dto.QuestionResponseDTO;
 import com.interviewmate.interview.controller.dto.AnswerRequestDTO;
-import com.interviewmate.interview.repository.AnswerMapper;
-import com.interviewmate.interview.repository.FeedbackMapper;
 import com.interviewmate.interview.service.InterviewService;
 import com.interviewmate.interview.service.model.InterviewInput;
 import com.interviewmate.interview.service.model.InterviewOutput;
 import io.swagger.v3.oas.annotations.Operation;
 import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -20,18 +19,12 @@ import org.springframework.web.bind.annotation.*;
 import java.net.URI;
 
 @RestController
+@RequiredArgsConstructor
 @RequestMapping("/api/interviews")
 public class InterviewController {
 
     private final InterviewService interviewService;
-    private final FeedbackMapper feedbackMapper;
-    private final AnswerMapper answerMapper;
 
-    public InterviewController(InterviewService interviewService, FeedbackMapper feedbackMapper, AnswerMapper answerMapper) {
-        this.interviewService = interviewService;
-        this.feedbackMapper = feedbackMapper;
-        this.answerMapper = answerMapper;
-    }
 
     @PostMapping
     @Operation(description = "Start new interview")

--- a/src/main/java/com/interviewmate/interview/controller/InterviewController.java
+++ b/src/main/java/com/interviewmate/interview/controller/InterviewController.java
@@ -3,6 +3,7 @@ package com.interviewmate.interview.controller;
 import ch.qos.logback.core.model.processor.PhaseIndicator;
 import com.interviewmate.exception.InterviewCreationException;
 import com.interviewmate.interview.controller.dto.*;
+import com.interviewmate.interview.domain.Question;
 import com.interviewmate.interview.service.InterviewService;
 import com.interviewmate.interview.service.model.InterviewInput;
 import com.interviewmate.interview.service.model.InterviewOutput;
@@ -88,8 +89,9 @@ public class InterviewController {
     )
     public ResponseEntity<QuestionResponseDTO> generateNextQuestion(@PathVariable String interviewId) {
 
-        QuestionResponseDTO nextQuestion = interviewService.generateNextQuestion(interviewId);
+        Question nextQuestion = interviewService.generateNextQuestion(interviewId);
+        QuestionResponseDTO nextQuestionResponse = new QuestionResponseDTO(nextQuestion.id(), nextQuestion.content());
 
-        return ResponseEntity.ok(nextQuestion);
+        return ResponseEntity.ok(nextQuestionResponse);
     }
 }

--- a/src/main/java/com/interviewmate/interview/controller/InterviewController.java
+++ b/src/main/java/com/interviewmate/interview/controller/InterviewController.java
@@ -1,12 +1,11 @@
 package com.interviewmate.interview.controller;
 
-import ch.qos.logback.core.model.processor.PhaseIndicator;
 import com.interviewmate.exception.InterviewCreationException;
-import com.interviewmate.interview.controller.dto.*;
-import com.interviewmate.interview.domain.Answer;
-import com.interviewmate.interview.domain.Feedback;
-import com.interviewmate.interview.domain.InterviewQuestion;
-import com.interviewmate.interview.domain.Question;
+import com.interviewmate.interview.controller.dto.AnswerResponseDTO;
+import com.interviewmate.interview.controller.dto.InterviewRequestDTO;
+import com.interviewmate.interview.controller.dto.InterviewResponseDTO;
+import com.interviewmate.interview.controller.dto.QuestionResponseDTO;
+import com.interviewmate.interview.controller.dto.AnswerRequestDTO;
 import com.interviewmate.interview.repository.AnswerMapper;
 import com.interviewmate.interview.repository.FeedbackMapper;
 import com.interviewmate.interview.service.InterviewService;
@@ -61,7 +60,10 @@ public class InterviewController {
 
         String questionId = interviewService.saveQuestion(interviewId, question);
 
-        QuestionResponseDTO questionResponse = new QuestionResponseDTO(questionId, question);
+        QuestionResponseDTO questionResponse = QuestionResponseDTO.builder()
+                .id(questionId)
+                .content(question)
+                .build();
 
         return ResponseEntity.ok(questionResponse);
     }
@@ -90,9 +92,8 @@ public class InterviewController {
     @Operation(description = "Generate next interview question")
     public ResponseEntity<QuestionResponseDTO> generateNextQuestion(@PathVariable String interviewId) {
 
-        Question question = interviewService.generateNextQuestion(interviewId);
-        QuestionResponseDTO nextQuestionResponse = new QuestionResponseDTO(question.id(), question.content());
+        QuestionResponseDTO response = interviewService.generateNextQuestion(interviewId);
 
-        return ResponseEntity.ok(nextQuestionResponse);
+        return ResponseEntity.ok(response);
     }
 }

--- a/src/main/java/com/interviewmate/interview/controller/InterviewController.java
+++ b/src/main/java/com/interviewmate/interview/controller/InterviewController.java
@@ -1,11 +1,7 @@
 package com.interviewmate.interview.controller;
 
 import com.interviewmate.exception.InterviewCreationException;
-import com.interviewmate.interview.controller.dto.AnswerResponseDTO;
-import com.interviewmate.interview.controller.dto.InterviewRequestDTO;
-import com.interviewmate.interview.controller.dto.InterviewResponseDTO;
-import com.interviewmate.interview.controller.dto.QuestionResponseDTO;
-import com.interviewmate.interview.controller.dto.AnswerRequestDTO;
+import com.interviewmate.interview.controller.dto.*;
 import com.interviewmate.interview.service.InterviewService;
 import com.interviewmate.interview.service.model.InterviewInput;
 import com.interviewmate.interview.service.model.InterviewOutput;
@@ -27,7 +23,10 @@ public class InterviewController {
 
 
     @PostMapping
-    @Operation(description = "Start new interview")
+    @Operation(
+            summary     = "인터뷰 생성",
+            description = "사용자가 입력한 userId와 topic으로 새로운 인터뷰를 생성하고, 생성된 인터뷰의 ID와 topic을 반환합니다."
+    )
     public ResponseEntity<InterviewResponseDTO> createInterview(@Valid @RequestBody InterviewRequestDTO request) {
 
         InterviewInput input = new InterviewInput(request.getUserId(), request.getTopic());
@@ -44,7 +43,10 @@ public class InterviewController {
     }
 
     @PostMapping("/{interviewId}/questions")
-    @Operation(description = "Generate interview question")
+    @Operation(
+            summary     = "면접 질문 생성",
+            description = "주어진 interviewId의 인터뷰 토픽을 조회한 뒤, 해당 토픽으로 새로운 질문을 생성하고 생성된 질문의 ID와 내용을 반환합니다."
+    )
     public ResponseEntity<QuestionResponseDTO> createQuestions(@PathVariable String interviewId) {
 
         String topic = interviewService.getTopicByInterviewId(interviewId);
@@ -62,7 +64,10 @@ public class InterviewController {
     }
 
     @PostMapping("/{interviewId}/questions/{questionId}/answers")
-    @Operation(description = "Submit only answer")
+    @Operation(
+            summary     = "답변 제출",
+            description = "주어진 interviewId와 questionId에 대해 사용자가 제출한 답변을 저장하고, 생성된 답변의 ID를 반환합니다."
+    )
     @ResponseStatus(HttpStatus.CREATED)
     public ResponseEntity<AnswerResponseDTO> submitAnswerAndFeedback(@PathVariable String interviewId, @PathVariable String questionId, @Valid @RequestBody AnswerRequestDTO answerRequestDTO) {
 
@@ -81,8 +86,28 @@ public class InterviewController {
                 + "/answers/" + answerId);
     }
 
+
+    @PostMapping("/{interviewId}/questions/{questionId}/answers/{answerId}/feedback")
+    @ResponseStatus(HttpStatus.CREATED)
+    @Operation(
+            summary     = "피드백 저장",
+            description = "사용자가 제출한 답변(answerId)에 대해 AI가 생성한 피드백을 저장하고, 저장된 피드백의 ID를 반환합니다."
+    )
+    public FeedbackResponseDTO submitFeedback(@PathVariable String interviewId, @PathVariable String questionId, @PathVariable String answerId, @Valid @RequestBody FeedbackRequestDTO request
+    ) {
+        String feedbackId = interviewService.submitFeedback(interviewId, questionId, answerId, request);
+
+        return new FeedbackResponseDTO(
+                feedbackId,
+                "피드백이 성공적으로 저장되었습니다."
+        );
+    }
+
     @PostMapping("{interviewId}/questions/next")
-    @Operation(description = "Generate next interview question")
+    @Operation(
+            summary     = "다음 질문 생성",
+            description = "주어진 interviewId의 인터뷰에서 마지막 질문, 답변, 피드백을 바탕으로 새로운 면접 질문을 생성하고, 생성된 질문의 ID와 내용을 반환합니다."
+    )
     public ResponseEntity<QuestionResponseDTO> generateNextQuestion(@PathVariable String interviewId) {
 
         QuestionResponseDTO response = interviewService.generateNextQuestion(interviewId);

--- a/src/main/java/com/interviewmate/interview/controller/dto/AnswerRequestDTO.java
+++ b/src/main/java/com/interviewmate/interview/controller/dto/AnswerRequestDTO.java
@@ -2,12 +2,8 @@ package com.interviewmate.interview.controller.dto;
 
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Size;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
 
-public record AnswerRequest(
+public record AnswerRequestDTO(
         @NotBlank(message = "사용자 ID는 필수입니다.") String userId,
         @NotBlank(message = "답변은 필수입니다.")
         @Size(max = 1000, message = "답변은 1000자 이내여야 합니다.") String content

--- a/src/main/java/com/interviewmate/interview/controller/dto/AnswerResponseDTO.java
+++ b/src/main/java/com/interviewmate/interview/controller/dto/AnswerResponseDTO.java
@@ -1,6 +1,5 @@
 package com.interviewmate.interview.controller.dto;
 
-import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -8,10 +7,10 @@ import lombok.NoArgsConstructor;
 @Getter
 @Builder
 @NoArgsConstructor
-public class AnswerResponse {
+public class AnswerResponseDTO {
 
     private String answerId;
-    public AnswerResponse (String answerId){
+    public AnswerResponseDTO(String answerId){
         this.answerId = answerId;
     }
 }

--- a/src/main/java/com/interviewmate/interview/controller/dto/FeedbackRequestDTO.java
+++ b/src/main/java/com/interviewmate/interview/controller/dto/FeedbackRequestDTO.java
@@ -1,0 +1,11 @@
+package com.interviewmate.interview.controller.dto;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record FeedbackRequestDTO(
+        @NotBlank
+        String userId,
+
+        @NotBlank
+        String content
+) { }

--- a/src/main/java/com/interviewmate/interview/controller/dto/FeedbackResponseDTO.java
+++ b/src/main/java/com/interviewmate/interview/controller/dto/FeedbackResponseDTO.java
@@ -1,0 +1,6 @@
+package com.interviewmate.interview.controller.dto;
+
+public record FeedbackResponseDTO(
+        String feedbackId,
+        String message
+) { }

--- a/src/main/java/com/interviewmate/interview/controller/dto/InterviewRequestDTO.java
+++ b/src/main/java/com/interviewmate/interview/controller/dto/InterviewRequestDTO.java
@@ -7,7 +7,7 @@ import jakarta.validation.constraints.NotBlank;
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
-public class InterviewRequest {
+public class InterviewRequestDTO {
 
     @NotBlank(message = "사용자 ID는 필수입니다.")
     private String userId;

--- a/src/main/java/com/interviewmate/interview/controller/dto/InterviewResponseDTO.java
+++ b/src/main/java/com/interviewmate/interview/controller/dto/InterviewResponseDTO.java
@@ -1,15 +1,13 @@
 package com.interviewmate.interview.controller.dto;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import lombok.Setter;
 
 @Getter
 @NoArgsConstructor
 @AllArgsConstructor
-public class InterviewResponse {
+public class InterviewResponseDTO {
 
     private String interviewId;
     private String topic;

--- a/src/main/java/com/interviewmate/interview/controller/dto/QuestionResponseDTO.java
+++ b/src/main/java/com/interviewmate/interview/controller/dto/QuestionResponseDTO.java
@@ -9,17 +9,15 @@ import java.sql.Timestamp;
 @Getter
 @AllArgsConstructor
 @NoArgsConstructor
-public class QuestionResponse {
+public class QuestionResponseDTO {
     private String id;
     private String content;
     private int questionOrder;
     private boolean isAnswered;
     private Timestamp createdAt;
 
-    public QuestionResponse(String id, String content) {
+    public QuestionResponseDTO(String id, String content) {
         this.id = id;
         this.content = content;
     }
 }
-
-

--- a/src/main/java/com/interviewmate/interview/controller/dto/QuestionResponseDTO.java
+++ b/src/main/java/com/interviewmate/interview/controller/dto/QuestionResponseDTO.java
@@ -1,6 +1,7 @@
 package com.interviewmate.interview.controller.dto;
 
 import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -9,6 +10,7 @@ import java.sql.Timestamp;
 @Getter
 @AllArgsConstructor
 @NoArgsConstructor
+@Builder
 public class QuestionResponseDTO {
     private String id;
     private String content;
@@ -16,8 +18,4 @@ public class QuestionResponseDTO {
     private boolean isAnswered;
     private Timestamp createdAt;
 
-    public QuestionResponseDTO(String id, String content) {
-        this.id = id;
-        this.content = content;
-    }
 }

--- a/src/main/java/com/interviewmate/interview/domain/Answer.java
+++ b/src/main/java/com/interviewmate/interview/domain/Answer.java
@@ -8,5 +8,4 @@ public record Answer(
         String content,
         LocalDateTime submittedAt,
         boolean isSubmitted
-) {
-}
+) {}

--- a/src/main/java/com/interviewmate/interview/domain/Feedback.java
+++ b/src/main/java/com/interviewmate/interview/domain/Feedback.java
@@ -5,7 +5,7 @@ import java.time.LocalDateTime;
 public record Feedback(
     String id,
     String answerId,
-    String perAnswerFeedback,
+    String feedbackContent,
     int score,
     String keywordHighlight,
     LocalDateTime createdAt

--- a/src/main/java/com/interviewmate/interview/domain/InterviewQuestion.java
+++ b/src/main/java/com/interviewmate/interview/domain/InterviewQuestion.java
@@ -1,14 +1,15 @@
 package com.interviewmate.interview.domain;
 
 import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import lombok.Setter;
 
-import java.sql.Timestamp;
+import java.time.LocalDateTime;
 
+
+@Builder
 @Getter
-@Setter
 @NoArgsConstructor
 @AllArgsConstructor
 public class InterviewQuestion {
@@ -17,5 +18,6 @@ public class InterviewQuestion {
     private String content;
     private int questionOrder;
     private boolean answered;
-    private Timestamp createdAt;
+    private LocalDateTime createdAt;
+
 }

--- a/src/main/java/com/interviewmate/interview/domain/Question.java
+++ b/src/main/java/com/interviewmate/interview/domain/Question.java
@@ -1,0 +1,12 @@
+package com.interviewmate.interview.domain;
+
+import java.time.LocalDateTime;
+
+public record Question(
+        String id,
+        String interviewId,
+        String content,
+        int questionOrder,
+        boolean isAnswered,
+        LocalDateTime createdAt
+) {}

--- a/src/main/java/com/interviewmate/interview/repository/AnswerMapper.java
+++ b/src/main/java/com/interviewmate/interview/repository/AnswerMapper.java
@@ -35,4 +35,16 @@ public interface AnswerMapper {
             WHERE id = #{id}
             """)
     Answer findById(String id);
+
+    @Select("""
+                SELECT 
+                    id,
+                    question_id AS questionId,
+                    content,
+                    created_at AS createdAt,
+                    is_final AS isFinal
+                FROM answers
+                WHERE question_id = #{questionId}
+            """)
+    Answer findByQuestionId(String questionId);
 }

--- a/src/main/java/com/interviewmate/interview/repository/AnswerMapper.java
+++ b/src/main/java/com/interviewmate/interview/repository/AnswerMapper.java
@@ -7,44 +7,45 @@ import org.apache.ibatis.annotations.Select;
 
 @Mapper
 public interface AnswerMapper {
+
     @Insert("""
-            INSERT INTO answer (
-              id,
-              question_id,
-              content,
-              submitted_at,
-              is_submitted
-            ) VALUES (
-              #{id},
-              #{questionId},
-              #{content},
-              #{submittedAt},
-              #{isSubmitted}
-            )
-            """)
+        INSERT INTO answer (
+            id,
+            question_id,
+            content,
+            submitted_at,
+            is_submitted
+        ) VALUES (
+            #{id},
+            #{questionId},
+            #{content},
+            #{submittedAt},
+            #{isSubmitted}
+        )
+        """)
     void insert(Answer answer);
 
     @Select("""
-            SELECT
-              id,
-              question_id   AS questionId,
-              content,
-              submitted_at  AS submittedAt,
-              is_submitted  AS isSubmitted
-            FROM answer
-            WHERE id = #{id}
-            """)
+        SELECT
+            id,
+            question_id     AS questionId,
+            content,
+            submitted_at    AS submittedAt,
+            is_submitted    AS isSubmitted
+        FROM answer
+        WHERE id = #{id}
+        """)
     Answer findById(String id);
 
     @Select("""
-                SELECT 
-                    id,
-                    question_id AS questionId,
-                    content,
-                    created_at AS createdAt,
-                    is_final AS isFinal
-                FROM answers
-                WHERE question_id = #{questionId}
-            """)
+        SELECT
+            id,
+            question_id     AS questionId,
+            content,
+            submitted_at    AS submittedAt,
+            is_submitted    AS isSubmitted
+        FROM answer
+        WHERE question_id = #{questionId}
+        """)
     Answer findByQuestionId(String questionId);
 }

--- a/src/main/java/com/interviewmate/interview/repository/FeedbackMapper.java
+++ b/src/main/java/com/interviewmate/interview/repository/FeedbackMapper.java
@@ -11,14 +11,14 @@ public interface FeedbackMapper {
             INSERT INTO feedback (
               id,
               answer_id,
-              per_answer_feedback,
+              feedback_content,
               score,
               keyword_highlight,
               created_at
             ) VALUES (
               #{id},
               #{answerId},
-              #{perAnswerFeedback},
+              #{feedbackContent},
               #{score},
               #{keywordHighlight},
               #{createdAt}
@@ -27,15 +27,15 @@ public interface FeedbackMapper {
     void insert(Feedback feedback);
 
     @Select("""
-                SELECT 
-                    id,
-                    answer_id,
-                    per_answer_feedback,
-                    score,
-                    keyword_highlight,
-                    created_at
-                FROM feedback
-                WHERE answer_id = #{answerId}
+            SELECT
+              id,
+              answer_id          AS answerId,
+              feedback_content   AS feedbackContent,
+              score,
+              keyword_highlight  AS keywordHighlight,
+              created_at         AS createdAt
+            FROM feedback
+            WHERE answer_id = #{answerId}
             """)
     Feedback findByAnswerId(String answerId);
 

--- a/src/main/java/com/interviewmate/interview/repository/FeedbackMapper.java
+++ b/src/main/java/com/interviewmate/interview/repository/FeedbackMapper.java
@@ -39,5 +39,4 @@ public interface FeedbackMapper {
             """)
     Feedback findByAnswerId(String answerId);
 
-
 }

--- a/src/main/java/com/interviewmate/interview/repository/InterviewQuestionMapper.java
+++ b/src/main/java/com/interviewmate/interview/repository/InterviewQuestionMapper.java
@@ -4,46 +4,75 @@ import com.interviewmate.interview.domain.InterviewQuestion;
 import org.apache.ibatis.annotations.Insert;
 import org.apache.ibatis.annotations.Mapper;
 import org.apache.ibatis.annotations.Select;
+import org.apache.ibatis.annotations.Update;
 
 import java.util.List;
 
 @Mapper
 public interface InterviewQuestionMapper {
 
+    /** 1) 새 질문 저장 */
     @Insert("""
-            INSERT INTO questions
-              (id, interview_id, content, question_order, is_answered, created_at)
-            VALUES
-              (#{id}, #{interviewId}, #{content}, #{questionOrder}, #{answered}, #{createdAt})
-            """)
+        INSERT INTO questions
+          (id, interview_id, content, question_order, is_answered, created_at)
+        VALUES
+          (#{id}, #{interviewId}, #{content}, #{questionOrder}, #{answered}, #{createdAt})
+        """)
     void insert(InterviewQuestion question);
 
+    /** 2) 인터뷰 내 모든 질문 조회 (생성 순) */
     @Select("""
-            SELECT
-              id,
-              interview_id     AS interviewId,
-              content,
-              question_order   AS questionOrder,
-              is_answered      AS answered,
-              created_at       AS createdAt
-            FROM questions
-            WHERE interview_id = #{interviewId}
-            ORDER BY question_order
-            """)
+        SELECT
+          id,
+          interview_id     AS interviewId,
+          content,
+          question_order   AS questionOrder,
+          is_answered      AS answered,
+          created_at       AS createdAt
+        FROM questions
+        WHERE interview_id = #{interviewId}
+        ORDER BY question_order ASC
+        """)
     List<InterviewQuestion> findByInterviewId(String interviewId);
 
+    /** 3) 첫 질문(제일 낮은 order) 하나만 조회 */
     @Select("""
-            SELECT
-              id,
-              interview_id     AS interviewId,
-              content,
-              question_order   AS questionOrder,
-              is_answered      AS answered,
-              created_at       AS createdAt
-            FROM questions
-            WHERE interview_id = #{interviewId}
-            ORDER BY question_order DESC
-            LIMIT 1
-            """)
+        SELECT
+          id,
+          interview_id     AS interviewId,
+          content,
+          question_order   AS questionOrder,
+          is_answered      AS answered,
+          created_at       AS createdAt
+        FROM questions
+        WHERE interview_id = #{interviewId}
+        ORDER BY question_order ASC
+        LIMIT 1
+        """)
     InterviewQuestion findTopByInterviewIdOrderByQuestionOrderDesc(String interviewId);
+
+    /** 4) 질문에 답변 달린 상태로 표시 */
+    @Update("""
+        UPDATE questions
+           SET is_answered = TRUE
+         WHERE id = #{questionId}
+        """)
+    void markAnswered(String questionId);
+
+    /** 5) 마지막으로 답변된 질문 하나만 조회 */
+    @Select("""
+        SELECT
+          id,
+          interview_id     AS interviewId,
+          content,
+          question_order   AS questionOrder,
+          is_answered      AS answered,
+          created_at       AS createdAt
+        FROM questions
+        WHERE interview_id = #{interviewId}
+          AND is_answered = TRUE
+        ORDER BY question_order DESC
+        LIMIT 1
+        """)
+    InterviewQuestion findLastAnsweredQuestion(String interviewId);
 }

--- a/src/main/java/com/interviewmate/interview/repository/InterviewQuestionMapper.java
+++ b/src/main/java/com/interviewmate/interview/repository/InterviewQuestionMapper.java
@@ -31,4 +31,19 @@ public interface InterviewQuestionMapper {
             ORDER BY question_order
             """)
     List<InterviewQuestion> findByInterviewId(String interviewId);
+
+    @Select("""
+            SELECT
+              id,
+              interview_id     AS interviewId,
+              content,
+              question_order   AS questionOrder,
+              is_answered      AS answered,
+              created_at       AS createdAt
+            FROM questions
+            WHERE interview_id = #{interviewId}
+            ORDER BY question_order DESC
+            LIMIT 1
+            """)
+    InterviewQuestion findTopByInterviewIdOrderByQuestionOrderDesc(String interviewId);
 }

--- a/src/main/java/com/interviewmate/interview/service/InterviewService.java
+++ b/src/main/java/com/interviewmate/interview/service/InterviewService.java
@@ -1,7 +1,7 @@
 package com.interviewmate.interview.service;
 
 import com.interviewmate.interview.controller.dto.AnswerRequestDTO;
-import com.interviewmate.interview.domain.Question;
+import com.interviewmate.interview.controller.dto.QuestionResponseDTO;
 import com.interviewmate.interview.service.model.InterviewInput;
 import com.interviewmate.interview.service.model.InterviewOutput;
 
@@ -20,5 +20,6 @@ public interface InterviewService {
 
     String saveFeedback(String answerId);
 
-    Question generateNextQuestion(String interviewId);
+    QuestionResponseDTO generateNextQuestion(String interviewId);
+
 }

--- a/src/main/java/com/interviewmate/interview/service/InterviewService.java
+++ b/src/main/java/com/interviewmate/interview/service/InterviewService.java
@@ -1,6 +1,7 @@
 package com.interviewmate.interview.service;
 
-import com.interviewmate.interview.controller.dto.AnswerRequest;
+import com.interviewmate.interview.controller.dto.AnswerRequestDTO;
+import com.interviewmate.interview.controller.dto.QuestionResponseDTO;
 import com.interviewmate.interview.service.model.InterviewInput;
 import com.interviewmate.interview.service.model.InterviewOutput;
 
@@ -15,7 +16,9 @@ public interface InterviewService {
 
     String saveQuestion(String interviewId, String question);
 
-    String submitAnswer(String interviewId, String questionId, AnswerRequest answer);
+    String submitAnswer(String interviewId, String questionId, AnswerRequestDTO answer);
 
     String saveFeedback(String answerId);
+
+    QuestionResponseDTO generateNextQuestion(String interviewId);
 }

--- a/src/main/java/com/interviewmate/interview/service/InterviewService.java
+++ b/src/main/java/com/interviewmate/interview/service/InterviewService.java
@@ -1,7 +1,7 @@
 package com.interviewmate.interview.service;
 
 import com.interviewmate.interview.controller.dto.AnswerRequestDTO;
-import com.interviewmate.interview.controller.dto.QuestionResponseDTO;
+import com.interviewmate.interview.domain.Question;
 import com.interviewmate.interview.service.model.InterviewInput;
 import com.interviewmate.interview.service.model.InterviewOutput;
 
@@ -20,5 +20,5 @@ public interface InterviewService {
 
     String saveFeedback(String answerId);
 
-    QuestionResponseDTO generateNextQuestion(String interviewId);
+    Question generateNextQuestion(String interviewId);
 }

--- a/src/main/java/com/interviewmate/interview/service/InterviewService.java
+++ b/src/main/java/com/interviewmate/interview/service/InterviewService.java
@@ -1,6 +1,7 @@
 package com.interviewmate.interview.service;
 
 import com.interviewmate.interview.controller.dto.AnswerRequestDTO;
+import com.interviewmate.interview.controller.dto.FeedbackRequestDTO;
 import com.interviewmate.interview.controller.dto.QuestionResponseDTO;
 import com.interviewmate.interview.service.model.InterviewInput;
 import com.interviewmate.interview.service.model.InterviewOutput;
@@ -22,4 +23,5 @@ public interface InterviewService {
 
     QuestionResponseDTO generateNextQuestion(String interviewId);
 
+    String submitFeedback(String interviewId, String questionId, String answerId, FeedbackRequestDTO request);
 }

--- a/src/main/java/com/interviewmate/interview/service/InterviewServiceImpl.java
+++ b/src/main/java/com/interviewmate/interview/service/InterviewServiceImpl.java
@@ -17,8 +17,6 @@ import org.springframework.ai.chat.messages.Message;
 import org.springframework.ai.chat.messages.SystemMessage;
 import org.springframework.ai.chat.messages.UserMessage;
 import org.springframework.stereotype.Service;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.slf4j.MDC;
 
 
@@ -183,7 +181,7 @@ public class InterviewServiceImpl implements InterviewService {
     }
 
     @Override
-    public Question generateNextQuestion(String interviewId) {
+    public QuestionResponseDTO generateNextQuestion(String interviewId) {
 
         InterviewQuestion lastQuestion = interviewQuestionMapper.findTopByInterviewIdOrderByQuestionOrderDesc(interviewId);
 
@@ -212,12 +210,12 @@ public class InterviewServiceImpl implements InterviewService {
                 .build();
         interviewQuestionMapper.insert(newQuestion);
 
-        return new Question(
-                newQuestion.getId(),
-                newQuestion.getInterviewId(),
-                newQuestion.getContent(),
-                newQuestion.getQuestionOrder(),
-                newQuestion.isAnswered(),
-                newQuestion.getCreatedAt());
+        return QuestionResponseDTO.builder()
+                .id(newQuestion.getId())
+                .content(newQuestion.getContent())
+                .questionOrder(newQuestion.getQuestionOrder())
+                .isAnswered(newQuestion.isAnswered())
+                .createdAt(Timestamp.valueOf(newQuestion.getCreatedAt()))
+                .build();
     }
 }

--- a/src/main/java/com/interviewmate/interview/service/InterviewServiceImpl.java
+++ b/src/main/java/com/interviewmate/interview/service/InterviewServiceImpl.java
@@ -185,10 +185,26 @@ public class InterviewServiceImpl implements InterviewService {
     public Question generateNextQuestion(String interviewId) {
 
         InterviewQuestion lastQuestion = interviewQuestionMapper.findTopByInterviewIdOrderByQuestionOrderDesc(interviewId);
-        //TODO
-        // 기능 구현 - ing
 
+        if (lastQuestion == null) throw new IllegalStateException("이전 질문이 존재하지 않습니다.");
 
+        Answer lastAnswer = answerMapper.findByQuestionId(lastQuestion.getId());
+        if (lastAnswer == null) throw new IllegalStateException("이전 질문에 대한 답변이 존재하지 않습니다.");
+
+        Feedback feedback = feedbackMapper.findByAnswerId(lastAnswer.id());
+        if (feedback == null) throw new IllegalStateException("피드백이 존재하지 않습니다.");
+
+        // 4. 프롬프트 구성 (Message 리스트 반환)
+
+        // 5. GPT 호출 → 질문 생성
+
+        // 6. 다음 질문 순서 계산
+
+        // 7. 인터뷰 질문 도메인 객체 생성
+
+        // 8. DB 저장
+
+        // 9. 도메인 객체로 반환
         return null;
     }
 }

--- a/src/main/java/com/interviewmate/interview/service/InterviewServiceImpl.java
+++ b/src/main/java/com/interviewmate/interview/service/InterviewServiceImpl.java
@@ -210,6 +210,10 @@ public class InterviewServiceImpl implements InterviewService {
                 .build();
         interviewQuestionMapper.insert(newQuestion);
 
+        if (nextOrder == 3) {
+            generateFinalFeedback(interviewId);
+        }
+
         return QuestionResponseDTO.builder()
                 .id(newQuestion.getId())
                 .content(newQuestion.getContent())
@@ -217,5 +221,9 @@ public class InterviewServiceImpl implements InterviewService {
                 .isAnswered(newQuestion.isAnswered())
                 .createdAt(Timestamp.valueOf(newQuestion.getCreatedAt()))
                 .build();
+    }
+    private void generateFinalFeedback(String interviewId) {
+        // TODO: 지금까지의 질문, 답변, 피드백을 인터뷰 ID 기준으로 모두 조회
+        // TODO: GPT 프롬프트 구성 및 최종 피드백 생성 후 DB 저장
     }
 }

--- a/src/main/java/com/interviewmate/interview/service/InterviewServiceImpl.java
+++ b/src/main/java/com/interviewmate/interview/service/InterviewServiceImpl.java
@@ -1,6 +1,7 @@
 package com.interviewmate.interview.service;
 
-import com.interviewmate.interview.controller.dto.AnswerRequest;
+import com.interviewmate.interview.controller.dto.AnswerRequestDTO;
+import com.interviewmate.interview.controller.dto.QuestionResponseDTO;
 import com.interviewmate.interview.domain.Answer;
 import com.interviewmate.interview.domain.Feedback;
 import com.interviewmate.interview.domain.Interview;
@@ -133,14 +134,14 @@ public class InterviewServiceImpl implements InterviewService {
     }
 
     @Override
-    public String submitAnswer(String interviewId, String questionId, AnswerRequest answerRequest) {
+    public String submitAnswer(String interviewId, String questionId, AnswerRequestDTO answerRequestDTO) {
 
         String answerId = UUID.randomUUID().toString();
 
         Answer answer = new Answer(
                 answerId,
                 questionId,
-                answerRequest.content(),
+                answerRequestDTO.content(),
                 LocalDateTime.now(),
                 true
         );
@@ -183,5 +184,17 @@ public class InterviewServiceImpl implements InterviewService {
         return feedbackId;
     }
 
-
+    @Override
+    public QuestionResponseDTO generateNextQuestion(String interviewId){
+        /**
+         * submitAnswerAndFeedback에서 에서 "직전질문 + 답변 + 피드백"을 가지고 GPT한테 다시 질문을 요청한다.
+         * 1.
+         *  1.1 마지막 질문조회
+         *  1.2 마지막 답변 조회
+         *  1.3 마지막 피드백 조회
+         * 2. 메서드 "꼬리 질문" 메서드로 보내서 질문을 받아온다.
+         *  2.1 질문을 저장한다.
+         *  2.2 질문을 return 한다. */
+        return null;
+    }
 }

--- a/src/main/java/com/interviewmate/interview/service/InterviewServiceImpl.java
+++ b/src/main/java/com/interviewmate/interview/service/InterviewServiceImpl.java
@@ -2,10 +2,7 @@ package com.interviewmate.interview.service;
 
 import com.interviewmate.interview.controller.dto.AnswerRequestDTO;
 import com.interviewmate.interview.controller.dto.QuestionResponseDTO;
-import com.interviewmate.interview.domain.Answer;
-import com.interviewmate.interview.domain.Feedback;
-import com.interviewmate.interview.domain.Interview;
-import com.interviewmate.interview.domain.InterviewQuestion;
+import com.interviewmate.interview.domain.*;
 import com.interviewmate.interview.repository.AnswerMapper;
 import com.interviewmate.interview.repository.FeedbackMapper;
 import com.interviewmate.interview.repository.InterviewMapper;
@@ -185,16 +182,13 @@ public class InterviewServiceImpl implements InterviewService {
     }
 
     @Override
-    public QuestionResponseDTO generateNextQuestion(String interviewId){
-        /**
-         * submitAnswerAndFeedback에서 에서 "직전질문 + 답변 + 피드백"을 가지고 GPT한테 다시 질문을 요청한다.
-         * 1.
-         *  1.1 마지막 질문조회
-         *  1.2 마지막 답변 조회
-         *  1.3 마지막 피드백 조회
-         * 2. 메서드 "꼬리 질문" 메서드로 보내서 질문을 받아온다.
-         *  2.1 질문을 저장한다.
-         *  2.2 질문을 return 한다. */
+    public Question generateNextQuestion(String interviewId) {
+
+        InterviewQuestion lastQuestion = interviewQuestionMapper.findTopByInterviewIdOrderByQuestionOrderDesc(interviewId);
+        //TODO
+        // 기능 구현 - ing
+
+
         return null;
     }
 }

--- a/src/main/java/com/interviewmate/interview/service/gpt/AiPromptBuilder.java
+++ b/src/main/java/com/interviewmate/interview/service/gpt/AiPromptBuilder.java
@@ -1,0 +1,31 @@
+package com.interviewmate.interview.service.gpt;
+
+import com.interviewmate.interview.domain.Answer;
+import com.interviewmate.interview.domain.Feedback;
+import com.interviewmate.interview.domain.InterviewQuestion;
+import org.springframework.ai.chat.messages.Message;
+import org.springframework.ai.chat.messages.SystemMessage;
+import org.springframework.ai.chat.messages.UserMessage;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class AiPromptBuilder {
+
+    public List<Message> buildPrompt(InterviewQuestion question, Answer answer, Feedback feedback) {
+        List<Message> promptMessages = new ArrayList<>();
+
+        promptMessages.add(new SystemMessage(
+                "너는 10년차 IT기업 백엔드 면접관이야. 아래는 한 지원자의 답변과 이전 피드백이야.\n" +
+                        "이전 피드백을 반영해서 다음 면접 질문을 생성해줘.\n" +
+                        "질문은 직무 적합성을 평가할 수 있도록 기술적으로 구체적이고, 핵심 역량을 검증할 수 있는 방향으로 작성해줘.\n" +
+                        "한 번에 하나의 질문만 작성해줘."
+        ));
+
+        promptMessages.add(new UserMessage("이전 질문: " + question.getContent()));
+        promptMessages.add(new UserMessage("사용자 답변: " + answer.content()));
+        promptMessages.add(new UserMessage("피드백: " + feedback.perAnswerFeedback()));
+
+        return promptMessages;
+    }
+}

--- a/src/main/java/com/interviewmate/interview/service/gpt/AiPromptBuilder.java
+++ b/src/main/java/com/interviewmate/interview/service/gpt/AiPromptBuilder.java
@@ -6,10 +6,12 @@ import com.interviewmate.interview.domain.InterviewQuestion;
 import org.springframework.ai.chat.messages.Message;
 import org.springframework.ai.chat.messages.SystemMessage;
 import org.springframework.ai.chat.messages.UserMessage;
+import org.springframework.stereotype.Component;
 
 import java.util.ArrayList;
 import java.util.List;
 
+@Component
 public class AiPromptBuilder {
 
     public List<Message> buildPrompt(InterviewQuestion question, Answer answer, Feedback feedback) {

--- a/src/main/java/com/interviewmate/interview/service/gpt/AiPromptBuilder.java
+++ b/src/main/java/com/interviewmate/interview/service/gpt/AiPromptBuilder.java
@@ -26,7 +26,7 @@ public class AiPromptBuilder {
 
         promptMessages.add(new UserMessage("이전 질문: " + question.getContent()));
         promptMessages.add(new UserMessage("사용자 답변: " + answer.content()));
-        promptMessages.add(new UserMessage("피드백: " + feedback.perAnswerFeedback()));
+        promptMessages.add(new UserMessage("피드백: " + feedback.feedbackContent()));
 
         return promptMessages;
     }

--- a/src/test/java/com/interviewmate/interview/controller/InterviewControllerApiTest.java
+++ b/src/test/java/com/interviewmate/interview/controller/InterviewControllerApiTest.java
@@ -2,9 +2,8 @@ package com.interviewmate.interview.controller;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.interviewmate.exception.InterviewNotFoundException;
-import com.interviewmate.interview.controller.dto.AnswerRequest;
-import com.interviewmate.interview.controller.dto.InterviewRequest;
-import com.interviewmate.interview.domain.Feedback;
+import com.interviewmate.interview.controller.dto.AnswerRequestDTO;
+import com.interviewmate.interview.controller.dto.InterviewRequestDTO;
 import com.interviewmate.interview.repository.*;
 import com.interviewmate.interview.service.InterviewService;
 import com.interviewmate.interview.service.model.InterviewOutput;
@@ -53,7 +52,7 @@ class InterviewControllerApiTest {
 
     @Test
     void createInterview_API정상호출() throws Exception {
-        InterviewRequest request = InterviewRequest.builder()
+        InterviewRequestDTO request = InterviewRequestDTO.builder()
                 .userId("user-123")
                 .topic("백엔드 개발")
                 .build();
@@ -78,7 +77,7 @@ class InterviewControllerApiTest {
 
     @Test
     void createInterview_IDNull일때_에러처리() throws Exception {
-        InterviewRequest request = InterviewRequest.builder()
+        InterviewRequestDTO request = InterviewRequestDTO.builder()
                 .userId("user-123")
                 .topic("백엔드 개발")
                 .build();
@@ -104,7 +103,7 @@ class InterviewControllerApiTest {
 
     @Test
     void createInterview_유효성_실패시_400에러() throws Exception {
-        InterviewRequest request = InterviewRequest.builder()
+        InterviewRequestDTO request = InterviewRequestDTO.builder()
                 .userId(null)
                 .topic("백엔드 개발")
                 .build();
@@ -135,7 +134,7 @@ class InterviewControllerApiTest {
                 .willThrow(new InterviewNotFoundException("해당 interviewId에 대한 정보가 없습니다."));
 
         String topic = "spring";
-        InterviewRequest request = InterviewRequest.builder()
+        InterviewRequestDTO request = InterviewRequestDTO.builder()
                 .userId("user-123")
                 .topic(topic)
                 .build();
@@ -152,7 +151,7 @@ class InterviewControllerApiTest {
     @Test
     void createInterview_topic이_null이면_400에러() throws Exception {
 
-        InterviewRequest request = InterviewRequest.builder()
+        InterviewRequestDTO request = InterviewRequestDTO.builder()
                 .userId("user-123")
                 .topic(null)
                 .build();
@@ -169,7 +168,7 @@ class InterviewControllerApiTest {
     @Test
     void saveAnswer_정상동작_답변과피드백ID반환() throws Exception {
 
-        AnswerRequest request = new AnswerRequest(
+        AnswerRequestDTO request = new AnswerRequestDTO(
                 "user-123",
                 "HTTPS는 HTTP보다 보안성이 강화된 프로토콜입니다."
         );

--- a/src/test/java/com/interviewmate/interview/controller/InterviewControllerIntegrationTest.java
+++ b/src/test/java/com/interviewmate/interview/controller/InterviewControllerIntegrationTest.java
@@ -13,7 +13,6 @@ import org.mybatis.spring.annotation.MapperScan;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.http.ResponseEntity;
 import org.springframework.test.context.jdbc.Sql;
 import org.springframework.test.context.jdbc.Sql.ExecutionPhase;
 import org.springframework.test.web.servlet.MockMvc;
@@ -56,7 +55,7 @@ class InterviewControllerIntegrationTest {
 
     @Test
     void createInterview_DB까지저장확인() throws Exception {
-        InterviewRequest request = InterviewRequest.builder()
+        InterviewRequestDTO request = InterviewRequestDTO.builder()
                 .userId("user-123")
                 .topic("spring")
                 .build();
@@ -68,7 +67,7 @@ class InterviewControllerIntegrationTest {
                 .andReturn();
 
         String json = mvcResult.getResponse().getContentAsString();
-        InterviewResponse resp = objectMapper.readValue(json, InterviewResponse.class);
+        InterviewResponseDTO resp = objectMapper.readValue(json, InterviewResponseDTO.class);
         String interviewId = resp.getInterviewId();
 
         var saved = interviewMapper.findById(interviewId);
@@ -80,7 +79,7 @@ class InterviewControllerIntegrationTest {
     @Test
     void createQuestion_정상동작_인터뷰ID로_질문생성요청() throws Exception {
         String topic = "spring";
-        InterviewRequest request = InterviewRequest.builder()
+        InterviewRequestDTO request = InterviewRequestDTO.builder()
                 .userId("user-123")
                 .topic(topic)
                 .build();
@@ -92,7 +91,7 @@ class InterviewControllerIntegrationTest {
                 .andReturn();
 
         String json = mvcResult.getResponse().getContentAsString();
-        InterviewResponse resp = objectMapper.readValue(json, InterviewResponse.class);
+        InterviewResponseDTO resp = objectMapper.readValue(json, InterviewResponseDTO.class);
         String interviewId = resp.getInterviewId();
 
         String url = "/api/interviews/" + interviewId + "/questions";
@@ -102,7 +101,7 @@ class InterviewControllerIntegrationTest {
                 .andReturn();
 
         String questionResponse = createQuestion.getResponse().getContentAsString();
-        QuestionResponse response = objectMapper.readValue(questionResponse, QuestionResponse.class);
+        QuestionResponseDTO response = objectMapper.readValue(questionResponse, QuestionResponseDTO.class);
 
         String question = response.getContent();
         assertThat(question).isNotNull();
@@ -115,7 +114,7 @@ class InterviewControllerIntegrationTest {
 
         String topic = "spring";
 
-        InterviewRequest request = InterviewRequest.builder()
+        InterviewRequestDTO request = InterviewRequestDTO.builder()
                 .userId(userId)
                 .topic(topic)
                 .build();
@@ -129,7 +128,7 @@ class InterviewControllerIntegrationTest {
 
         String json = mvcResult.getResponse().getContentAsString();
 
-        InterviewResponse resp = objectMapper.readValue(json, InterviewResponse.class);
+        InterviewResponseDTO resp = objectMapper.readValue(json, InterviewResponseDTO.class);
 
         String interviewId = resp.getInterviewId();
 
@@ -140,10 +139,10 @@ class InterviewControllerIntegrationTest {
                 .andReturn();
 
         String questionJson = createQuestion.getResponse().getContentAsString();
-        QuestionResponse questionResponse = objectMapper.readValue(questionJson, QuestionResponse.class);
-        String questionId = questionResponse.getId();
+        QuestionResponseDTO questionResponseDTO = objectMapper.readValue(questionJson, QuestionResponseDTO.class);
+        String questionId = questionResponseDTO.getId();
 
-        AnswerRequest answerRequest = new AnswerRequest(
+        AnswerRequestDTO answerRequestDTO = new AnswerRequestDTO(
                 "user-123",
                 "HTTPS는 HTTP보다 보안성이 강화된 프로토콜입니다."
         );
@@ -152,13 +151,13 @@ class InterviewControllerIntegrationTest {
 
         var createAnswer = mockMvc.perform(post(endToEndUrl)
                         .contentType("application/json")
-                        .content(objectMapper.writeValueAsString(answerRequest)))
+                        .content(objectMapper.writeValueAsString(answerRequestDTO)))
                 .andExpect(status().isCreated())
                 .andReturn();
 
         String answerJson = createAnswer.getResponse().getContentAsString();
-        AnswerResponse answerResponse = objectMapper.readValue(answerJson, AnswerResponse.class);
-        String answerId = answerResponse.getAnswerId();
+        AnswerResponseDTO answerResponseDTO = objectMapper.readValue(answerJson, AnswerResponseDTO.class);
+        String answerId = answerResponseDTO.getAnswerId();
 
         assertThat(answerId).isNotNull();
         assertThat(answerId).isNotBlank();

--- a/src/test/java/com/interviewmate/interview/service/InterviewServiceTest.java
+++ b/src/test/java/com/interviewmate/interview/service/InterviewServiceTest.java
@@ -1,6 +1,6 @@
 package com.interviewmate.interview.service;
 
-import com.interviewmate.interview.controller.dto.AnswerRequest;
+import com.interviewmate.interview.controller.dto.AnswerRequestDTO;
 import com.interviewmate.interview.domain.Answer;
 import com.interviewmate.interview.domain.Feedback;
 import com.interviewmate.interview.repository.AnswerMapper;
@@ -87,9 +87,9 @@ class InterviewServiceTest {
 
         String interviewId = "intv-123";
         String questionId = "q-456";
-        AnswerRequest answerRequest = new AnswerRequest("user-123","사용자 답변 내용");
+        AnswerRequestDTO answerRequestDTO = new AnswerRequestDTO("user-123","사용자 답변 내용");
 
-        String answerId = interviewService.submitAnswer(interviewId, questionId, answerRequest);
+        String answerId = interviewService.submitAnswer(interviewId, questionId, answerRequestDTO);
 
         assertNotNull(answerId);
 
@@ -99,7 +99,7 @@ class InterviewServiceTest {
         Answer saved = captor.getValue();
 
         assertEquals(questionId, saved.questionId());
-        assertEquals(answerRequest.content(), saved.content());
+        assertEquals(answerRequestDTO.content(), saved.content());
     }
     @Test
     void saveFeedback_givenValidAnswerId_fetchesAnswerAndInsertsFeedback() {


### PR DESCRIPTION
# 📝 PR Template

## 📌 변경 사항  
✅ PR 제목 예시: `[draft] feat: 인터뷰 다음 질문 생성 API 구현 (POST /api/interviews/{interviewId}/questions/next)`  
- [x] 신규 기능 추가  
- [ ] 버그 수정  
- [x] 코드 리팩토링  
- [ ] 문서 업데이트  
- [ ] 기타  

---

## 🔍 변경 내용 요약  
- 다음 질문(꼬리질문)을 생성하는 API Controller 레벨 구현 완료  
- `InterviewController`에 `generateNextQuestion()` 메서드 추가  
- `interviewService.generateNextQuestion()` 호출 흐름 연결  
- 응답 객체로 `QuestionResponseDTO` 사용  
- Swagger description 명시 (`"Generate next interview question"`)  
- 리턴 변수명을 `response`, `dto` → `questionResponse`, `interviewResponse` 등으로 명확화  
- DTO 네이밍 정리 (`QuestionResponseDTO`, `AnswerRequestDTO`, `InterviewResponseDTO` 등 역할 중심 이름 통일)

---

## ❓ 변경 이유  
- 인터뷰 흐름 중 사용자 답변 기반으로 **다음 질문(GPT 생성)** 을 생성하는 기능 설계의 첫 단계  
- 먼저 Controller → Service 흐름 연결 후, Service 내부 로직은 다음 단계에서 구현 예정  
- 기존 DTO 및 리턴 명명 방식이 불명확하여 가독성 개선 목적의 네이밍 리팩토링 진행

---

## 🛠 테스트 및 검증  
- [x] 로컬 실행 테스트 완료  
- [ ] 단위 테스트 통과 (`./gradlew test`)  
- [ ] API 요청 및 응답 확인 (`Swagger`로 확인)  
- [x] 코드 컨벤션 준수 (`Checkstyle` 적용)

---

## 🔗 연관 이슈  
- 없음 (초기 기능 구현 단계)

---

## 💡 추가 설명  
- Service 내부 로직 (`InterviewServiceImpl.generateNextQuestion()`) 은 추후 작업 예정  
- 질문 순서 관리, 마지막 질문/답변/피드백 기반 프롬프트 구성 및 GPT 호출 포함 예정  
- DTO 명명 및 컨트롤러 응답 구조 통일 작업 포함됨

---

## 👀 리뷰 요청  
- Controller 흐름 및 메서드 명세, API URI 설계 구조에 대해 중점 리뷰 부탁드립니다  
- Service 로직은 이후 구현 예정입니다.