### PR TITLE
[draft] test: endToEndTest_답변과피드백까지정상작동 로직 개선

### DIFF
--- a/src/main/java/com/interviewmate/interview/service/InterviewServiceImpl.java
+++ b/src/main/java/com/interviewmate/interview/service/InterviewServiceImpl.java
@@ -280,7 +280,7 @@ public class InterviewServiceImpl implements InterviewService {
                 .build();
     }
 
-    private void generateFinalFeedback(String interviewId) {
+    void generateFinalFeedback(String interviewId) {
         // TODO: 지금까지의 질문, 답변, 피드백을 인터뷰 ID 기준으로 모두 조회
         // TODO: GPT 프롬프트 구성 및 최종 피드백 생성 후 DB 저장
     }

--- a/src/test/java/com/interviewmate/interview/controller/InterviewControllerApiTest.java
+++ b/src/test/java/com/interviewmate/interview/controller/InterviewControllerApiTest.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.interviewmate.exception.InterviewNotFoundException;
 import com.interviewmate.interview.controller.dto.AnswerRequestDTO;
 import com.interviewmate.interview.controller.dto.InterviewRequestDTO;
+import com.interviewmate.interview.controller.dto.QuestionResponseDTO;
 import com.interviewmate.interview.repository.*;
 import com.interviewmate.interview.service.InterviewService;
 import com.interviewmate.interview.service.model.InterviewOutput;
@@ -15,6 +16,9 @@ import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.MvcResult;
+
+import java.sql.Timestamp;
+import java.time.LocalDateTime;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
@@ -183,5 +187,28 @@ class InterviewControllerApiTest {
                         .content(objectMapper.writeValueAsString(request)))
                 .andExpect(status().isCreated())
                 .andExpect(jsonPath("$.answerId").value("answer-123"));
+    }
+    @Test
+    void generateNextQuestion_정상호출() throws Exception{
+
+        String interviewId = "test-id";
+
+        QuestionResponseDTO response = QuestionResponseDTO.builder()
+                .id("question_id")
+                .content("Moke : spring 관련 질문")
+                .questionOrder(2)
+                .isAnswered(false)
+                .createdAt(Timestamp.valueOf(LocalDateTime.now()))
+                .build();
+
+        given(interviewService.generateNextQuestion(interviewId)).willReturn(response);
+
+        mockMvc.perform(post("/api/interviews/{interviewId}/questions/next", interviewId)
+                .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.id").value("question_id"))
+                .andExpect(jsonPath("$.content").value("Moke : spring 관련 질문"))
+                .andExpect(jsonPath("$.questionOrder").value(2))
+                .andExpect(jsonPath("$.answered").value(false));
     }
 }

--- a/src/test/java/com/interviewmate/interview/service/InterviewServiceTest.java
+++ b/src/test/java/com/interviewmate/interview/service/InterviewServiceTest.java
@@ -3,6 +3,7 @@ package com.interviewmate.interview.service;
 import com.interviewmate.interview.controller.dto.AnswerRequestDTO;
 import com.interviewmate.interview.domain.Answer;
 import com.interviewmate.interview.domain.Feedback;
+import com.interviewmate.interview.domain.InterviewQuestion;
 import com.interviewmate.interview.repository.AnswerMapper;
 import com.interviewmate.interview.repository.FeedbackMapper;
 import com.interviewmate.interview.repository.InterviewMapper;
@@ -134,4 +135,11 @@ class InterviewServiceTest {
 
         assertNotNull(saveFeedback);
     }
+
+    @Test
+    void generateNextQuestion_정상호출_nextOrder2(){
+
+    }
+
+
 }

--- a/src/test/java/com/interviewmate/interview/service/InterviewServiceTest.java
+++ b/src/test/java/com/interviewmate/interview/service/InterviewServiceTest.java
@@ -130,7 +130,7 @@ class InterviewServiceTest {
         verify(feedbackMapper).insert(captor.capture());
 
         Feedback saved = captor.getValue();
-        assertEquals("AI 요약 피드백입니다", saved.perAnswerFeedback());
+        assertEquals("AI 요약 피드백입니다", saved.feedbackContent());
 
         assertNotNull(saveFeedback);
     }

--- a/src/test/java/com/interviewmate/interview/service/InterviewServiceTest.java
+++ b/src/test/java/com/interviewmate/interview/service/InterviewServiceTest.java
@@ -17,6 +17,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
+import org.mockito.Spy;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.ai.chat.messages.Message;
 import org.springframework.ai.chat.messages.SystemMessage;
@@ -24,11 +25,11 @@ import org.springframework.ai.chat.messages.SystemMessage;
 import java.time.LocalDateTime;
 import java.util.List;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.*;
+
 
 @ExtendWith(MockitoExtension.class)
 class InterviewServiceTest {
@@ -37,7 +38,7 @@ class InterviewServiceTest {
     private GptClient gptClient;
     @Mock
     private AnswerMapper answerMapper;
-    @InjectMocks
+    @Spy @InjectMocks
     private InterviewServiceImpl interviewService;
     @Mock
     private InterviewMapper interviewMapper;
@@ -47,6 +48,7 @@ class InterviewServiceTest {
     private FeedbackMapper feedbackMapper;
     @Mock
     private AiPromptBuilder aiPromptBuilder;
+
 
     @Test
     void createInterview_200_OK() {
@@ -96,7 +98,7 @@ class InterviewServiceTest {
 
         String interviewId = "intv-123";
         String questionId = "q-456";
-        AnswerRequestDTO answerRequestDTO = new AnswerRequestDTO("user-123","사용자 답변 내용");
+        AnswerRequestDTO answerRequestDTO = new AnswerRequestDTO("user-123", "사용자 답변 내용");
 
         String answerId = interviewService.submitAnswer(interviewId, questionId, answerRequestDTO);
 
@@ -110,6 +112,7 @@ class InterviewServiceTest {
         assertEquals(questionId, saved.questionId());
         assertEquals(answerRequestDTO.content(), saved.content());
     }
+
     @Test
     void saveFeedback_givenValidAnswerId_fetchesAnswerAndInsertsFeedback() {
 
@@ -191,6 +194,60 @@ class InterviewServiceTest {
         assertEquals("새 질문 내용", result.getContent());
         assertEquals(2, result.getQuestionOrder());
         assertEquals(false, result.isAnswered());
+    }
+
+    @Test
+    void generateNextQuestion_정상_nextOrder3() {
+
+        InterviewQuestion lastQuestion = InterviewQuestion.builder()
+                .id("question-id")
+                .interviewId("interview-id")
+                .content("기존 질문")
+                .questionOrder(2)
+                .answered(true)
+                .createdAt(LocalDateTime.now().minusMinutes(1))
+                .build();
+
+        Answer lastAnswer = new Answer("answer-id", "question-id", "사용자답변", LocalDateTime.now().minusMinutes(30), true);
+
+        Feedback feedback = new Feedback("feedback-id", "answer-id", "피드백", 9, "spring", LocalDateTime.now().minusMinutes(10));
+
+        List<Message> dummyMessages = List.of(new SystemMessage("dummy"));
+
+        AiChatResponse aiResponse = new AiChatResponse(new AiChatResult(new AiChatMessage("새 질문 내용")));
+
+
+        when(aiPromptBuilder.buildPrompt(any(InterviewQuestion.class), any(Answer.class), any(Feedback.class))).thenReturn(dummyMessages);
+        when(gptClient.generate(dummyMessages)).thenReturn(aiResponse);
+
+        when(interviewQuestionMapper.findLastAnsweredQuestion("interview-id")).thenReturn(lastQuestion);
+        when(answerMapper.findByQuestionId("question-id")).thenReturn(lastAnswer);
+        when(feedbackMapper.findByAnswerId("answer-id")).thenReturn(feedback);
+
+        ArgumentCaptor<InterviewQuestion> captor = ArgumentCaptor.forClass(InterviewQuestion.class);
+        doNothing().when(interviewQuestionMapper).insert(captor.capture());
+
+        QuestionResponseDTO result = interviewService.generateNextQuestion("interview-id");
+
+        InterviewQuestion saved = captor.getValue();
+        assertEquals("새 질문 내용", saved.getContent());
+        assertEquals(3, saved.getQuestionOrder());
+        assertFalse(saved.isAnswered());
+
+        assertEquals("새 질문 내용", result.getContent());
+        assertEquals(3, result.getQuestionOrder());
+        assertFalse(result.isAnswered());
+
+        verify(interviewService, times(1)).generateFinalFeedback("interview-id");
+    }
+
+    @Test
+    void generateNextQuestion_예외_lastQuestion없음() {
+
+        // given
+        // 1. when(interviewQuestionMapper.findLastAnsweredQuestion(...)) → null 반환 설정
+        // 2. answerMapper, feedbackMapper 호출 안 됨
+        // 3. assertThrows(IllegalStateException) 사용
     }
 
 


### PR DESCRIPTION
# 📝 PR Template

## 📌 변경 사항
✅ PR 제목: `[TEST] endToEndTest 로직 개선 및 안정성 확보`  
- [x] 신규 기능 추가  
- [ ] 버그 수정  
- [ ] 코드 리팩토링  
- [ ] 문서 업데이트  
- [x] 기타 (테스트 개선)  

## 🔍 변경 내용 요약  
- E2E(end-to-end) 테스트 로직 개선  
- GPT 응답 Mocking을 질문/피드백 2단계로 분리  
- 질문 생성 시 topic 검증 추가  
- 피드백 생성 시 HTTPS 포함 여부 검증 추가  
- 테스트 가독성과 안정성 향상을 위해 setup에 공통 mock 설정 적용  

## ❓ 변경 이유  
- 기존 E2E 테스트에서 GPT 호출 및 응답 내용이 랜덤 요소에 의해 불안정하게 동작  
- 검증 포인트가 명확하지 않아, 로직 변경 시 실패 원인 파악이 어려움  
- 안정성과 재현성을 높이기 위해 Mocking과 검증 로직을 명확하게 분리  

## 🛠 테스트 및 검증  
- [x] 로컬 실행 테스트 완료  
- [x] 단위 테스트 통과 (`./gradlew test`)  
- [x] API 요청 및 응답 확인 (`Postman` 또는 `Swagger`)  
- [x] 코드 컨벤션 준수 (`Checkstyle` 적용)  
- **테스트 커버리지 결과**  
  - 클래스: 80% (16/20)  
  - 메서드: 71% (33/46)  
  - 줄: 64% (145/224)  
  - 브랜치: 31% (7/22)  

## 🔗 연관 이슈  
- 없음  

## 💡 추가 설명  
- 이번 PR은 기능 로직 수정이 아닌 **테스트 코드 안정성 및 유지보수성 향상**이 목적임  

## 👀 리뷰 요청  
