### PR TITLE
[Draft] : generateNextQuestion와 final feedback(3번째 질문) 책임 분리

### DIFF
--- a/src/main/java/com/interviewmate/interview/service/InterviewServiceImpl.java
+++ b/src/main/java/com/interviewmate/interview/service/InterviewServiceImpl.java
@@ -260,8 +260,11 @@ public class InterviewServiceImpl implements InterviewService {
         interviewQuestionMapper.insert(newQuestion);
         MDC.put("dbElapsed", String.valueOf(System.currentTimeMillis() - dbStart));
 
+        // ⚠️ [리팩토링 대상] 세 번째 질문일 때 최종 피드백 호출
+        // TODO: generateFinalFeedback(interviewId)를 직접 호출하지 말고,
+        //       FinalFeedbackService(인터페이스) 같은 별도 컴포넌트를 주입받아 호출하도록 분리하면 테스트 용이성 ↑
         if (nextOrder == 3) {
-            generateFinalFeedback(interviewId);
+            generateFinalFeedback(interviewId); // ← 지금은 private 메소드, 테스트에서 접근 어려움
         }
 
         MDC.put("totalElapsed", String.valueOf(System.currentTimeMillis() - startTime));
@@ -280,6 +283,9 @@ public class InterviewServiceImpl implements InterviewService {
                 .build();
     }
 
+    // ⚠️ [리팩토링 대상] 최종 피드백 생성
+    // TODO: 지금은 내부 private 메소드인데, FinalFeedbackService(인터페이스) 같은 별도 서비스로 추출하고
+    //  인터뷰 종료 시점에만 호출되도록 InterviewServiceImpl에서는 트리거 역할만 하도록 개선 필요
     void generateFinalFeedback(String interviewId) {
         // TODO: 지금까지의 질문, 답변, 피드백을 인터뷰 ID 기준으로 모두 조회
         // TODO: GPT 프롬프트 구성 및 최종 피드백 생성 후 DB 저장


### PR DESCRIPTION
# 📝 PR Template

## 📌 변경 사항
✅ PR 제목 : `[Draft] generateNextQuestion와 FinalFeedback 책임 분리(예정)`
- [ ] 신규 기능 추가  
- [ ] 버그 수정  
- [x] 코드 리팩토링 (예정)  
- [ ] 문서 업데이트  
- [ ] 기타  

## 🔍 변경 내용 요약  
- (예정) `generateNextQuestion` 내부의 **질문 생성 로직**과 **최종 피드백 생성 트리거**를 분리
- (예정) `FinalFeedbackService` 도입 → 최종 피드백 생성/저장을 전담하도록 구조 개선
- (배경) 2/3번째 질문 흐름 테스트 작성 중 **SRP(단일 책임 원칙) 위배** 및 private 메서드 테스트 제약 확인

## ❓ 변경 이유  
- (발견) `InterviewServiceImpl`가 질문 생성과 최종 피드백까지 담당하여 책임 경계가 불명확
- (목표) 테스트 용이성 및 유지보수성 향상을 위해 **책임 분리** 적용

## 🛠 테스트 및 검증  
- [ ] 로컬 실행 테스트  
- [ ] 단위 테스트 (`./gradlew test`)  
- [ ] API 요청/응답 확인 (Postman/Swagger)  
- [ ] 코드 컨벤션 준수 (Checkstyle)  

## 🔗 연관 이슈  
<!-- 관련된 이슈 번호를 입력해주세요. (예: Closes #123) -->

## 💡 추가 설명  
- 

## 👀 리뷰 요청  
- 책임 분리 방향(서비스 추출 및 호출 시점)이 적절한지 의견부탁드립니다. 
